### PR TITLE
Set up the computed stitching parameters

### DIFF
--- a/image_stitcher/parameters.py
+++ b/image_stitcher/parameters.py
@@ -1,9 +1,18 @@
 import enum
+import json
+import math
 import os
+import pathlib
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Any, ClassVar, NamedTuple, assert_never
 
+import numpy as np
+import pandas as pd
+from dask_image.imread import imread as dask_imread
 from pydantic import AfterValidator, BaseModel
+
+DATETIME_FORMAT = "%Y-%m-%d_%H-%M-%S.%f"
 
 
 class OutputFormat(enum.Enum):
@@ -68,9 +77,7 @@ class StitchingParameters(BaseModel):
     def stitched_folder(self) -> str:
         """Path to folder containing stitched outputs."""
         return os.path.join(
-            self.input_folder
-            + "_stitched_"
-            + datetime.now().strftime("%Y-%m-%d_%H-%M-%S.%f")
+            self.input_folder + "_stitched_" + datetime.now().strftime(DATETIME_FORMAT)
         )
 
     @classmethod
@@ -94,3 +101,444 @@ class StitchingParameters(BaseModel):
         """
         with open(json_path, "w") as f:
             f.write(self.model_dump_json(indent=2))
+
+
+@dataclass
+class UnidirectionalScanPatternParams:
+    """Computed parameters for a unidirectional scan pattern."""
+
+    h_shift: tuple[int, int] = (0, 0)
+    v_shift: tuple[int, int] = (0, 0)
+
+
+class ReverseRows(enum.Enum):
+    """Whether an S-pattern reverses even or odd rows."""
+
+    even = "even"
+    odd = "odd"
+
+
+@dataclass
+class SPatternScanParams:
+    """Computed parameters for an S-pattern scan pattern."""
+
+    h_shift: tuple[int, int] = (0, 0)
+    v_shift: tuple[int, int] = (0, 0)
+    h_shift_rev: tuple[int, int] = (0, 0)
+    h_shift_rev_rows: ReverseRows = ReverseRows.even
+
+
+ScanParams = UnidirectionalScanPatternParams | SPatternScanParams
+
+
+def default_scan_params(pattern: ScanPattern) -> ScanParams:
+    match pattern:
+        case ScanPattern.unidirectional:
+            return UnidirectionalScanPatternParams()
+        case ScanPattern.s_pattern:
+            return SPatternScanParams()
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+class MetaKey(NamedTuple):
+    """A (timepoint, region, fov_idx, z_level, channel) key."""
+
+    t: int
+    region: str
+    fov: int
+    z_level: int
+    channel: str
+
+
+@dataclass
+class AcquisitionMetadata:
+    filepath: pathlib.Path
+    """Path to the image file."""
+    x: float
+    """X position of the stage in mm."""
+    y: float
+    """Y position of the stage in mm."""
+    z: float
+    """Z position of the stage in µm."""
+    channel: str
+    """The name of the channel."""
+    z_level: int
+    """The z-index of the current plane when z-sectioning a single field of view."""
+    region: str
+    fov_idx: int
+    """The index of the current field of view."""
+    t: int
+    """The current timepoint."""
+
+    @property
+    def key(self) -> MetaKey:
+        """A (timepoint, region, fov_idx, z_level, channel) key.
+
+        This uniquely identifies this image within an acquisition.
+        """
+        return MetaKey(self.t, self.region, self.fov_idx, self.z_level, self.channel)
+
+
+class ImagePlaneDims(NamedTuple):
+    width_px: int
+    height_px: int
+
+
+@dataclass
+class StitchingComputedParameters:
+    """Parameters computed from other parameters, images, or files on disk.
+
+    TODO(colin): refactor to remove all the defaults that end up never used.
+    """
+
+    CHUNK_SIZE_LIMIT_PX: ClassVar[int] = (
+        12288  # 12288 = 8192 + 4096, just arbitrarily chosen multiples of 1024
+    )
+    """An upper bound on the size of a dask array chunk.
+    
+    We assume many chunks can fit into memory at once, and for a single square
+    plane in float64, this works out to about 1GB/chunk.
+    """
+    parent: StitchingParameters
+    scan_params: ScanParams = field(init=False)
+    pixel_size_um: int = field(init=False)
+    pixel_binning: int = field(init=False)
+    num_z: int = field(init=False)
+    num_c: int = field(init=False)
+    num_t: int = field(init=False)
+    input_height: int = field(init=False)
+    input_width: int = field(init=False)
+    num_pyramid_levels: int = field(init=False)
+    acquisition_params: dict[str, Any] = field(init=False)
+    timepoints: list[int] = field(init=False)
+    monochrome_channels: list[str] = field(init=False)
+    monochrome_colors: list[int] = field(init=False)
+    # TODO(colin): fill in correct type when importing the flatfield code.
+    flatfields: dict[None, None] = field(init=False)
+    acquisition_metadata: dict[MetaKey, AcquisitionMetadata] = field(init=False)
+    dtype: np.dtype = field(init=False)
+    chunks: tuple[int, int, int, int, int] = field(init=False)
+    xy_positions: list[tuple[float, float]] = field(init=False)
+    regions: list[str] = field(default_factory=list)
+    channel_names: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.scan_params = default_scan_params(self.parent.scan_pattern)
+        self.init_timepoints()
+        self.init_acquisition_parameters()
+        self.init_pixel_size()
+        self.parse_acquisition_metadata()
+
+    def init_timepoints(self) -> None:
+        self.timepoints = [
+            int(d, 10)
+            for d in os.listdir(self.parent.input_folder)
+            if os.path.isdir(os.path.join(self.parent.input_folder, d)) and d.isdigit()
+        ]
+        self.timepoints.sort()
+
+    def init_acquisition_parameters(self) -> None:
+        acquistion_params_path = os.path.join(
+            self.parent.input_folder, "acquisition parameters.json"
+        )
+        with open(acquistion_params_path, "r") as file:
+            self.acquisition_params = json.load(file)
+
+    def init_pixel_size(self) -> None:
+        """Initialize the pixel size parameters.
+
+        This must be called after init_acquisition_params
+
+        TODO(colin): refactor so that there are not implicit dependencies
+        between these initialization functions.
+        """
+        obj_mag = self.acquisition_params["objective"]["magnification"]
+        obj_tube_lens_mm = self.acquisition_params["objective"]["tube_lens_f_mm"]
+        sensor_pixel_size_um = self.acquisition_params["sensor_pixel_size_um"]
+        tube_lens_mm = self.acquisition_params["tube_lens_mm"]
+        self.pixel_binning = self.acquisition_params.get("pixel_binning", 1)
+        assert isinstance(self.pixel_binning, int)
+        obj_focal_length_mm = obj_tube_lens_mm / obj_mag
+        actual_mag = tube_lens_mm / obj_focal_length_mm
+        self.pixel_size_um = sensor_pixel_size_um / actual_mag
+        print("pixel_size_um:", self.pixel_size_um)
+
+    def parse_acquisition_metadata(self) -> None:
+        """Parse image filenames and matche them to coordinates for stitching.
+
+        multiple channels, regions, timepoints, z levels
+
+        Must be called after self.init_timepoints().
+
+        TODO(colin): refactor so that there are not implicit dependencies
+        between these initialization functions.
+        """
+        input_path = pathlib.Path(self.parent.input_folder)
+        self.acquisition_metadata = {}
+        max_z = 0
+        max_fov = 0
+
+        # Iterate over each timepoint
+        for timepoint in self.timepoints:
+            image_folder = input_path / str(timepoint)
+            coordinates_path = image_folder / "coordinates.csv"
+
+            print(f"Processing timepoint {timepoint}, image folder: {image_folder}")
+
+            try:
+                coordinates_df = pd.read_csv(coordinates_path)
+            except FileNotFoundError:
+                print(f"Warning: coordinates.csv not found for timepoint {timepoint}")
+                continue
+
+            # Process each image file
+            image_files = sorted(
+                [
+                    f.resolve()
+                    for f in image_folder.iterdir()
+                    if f.suffix in (".bmp", ".tiff", ".tif", ".jpg", ".jpeg", ".png")
+                    and "focus_camera" not in f.name
+                ]
+            )
+
+            for file in image_files:
+                parts = file.name.split("_", 3)
+                region, fov, z_level, channel = (
+                    parts[0],
+                    int(parts[1]),
+                    int(parts[2]),
+                    os.path.splitext(parts[3])[0],
+                )
+                channel = channel.replace("_", " ").replace("full ", "full_")
+
+                coord_rows = coordinates_df[
+                    (coordinates_df["region"] == region)
+                    & (coordinates_df["fov"] == fov)
+                    & (coordinates_df["z_level"] == z_level)
+                ]
+
+                if coord_rows.empty:
+                    print(f"Warning: No coordinates for {file}")
+                    continue
+
+                coord_row = coord_rows.iloc[0]
+
+                meta = AcquisitionMetadata(
+                    filepath=file,
+                    x=coord_row["x (mm)"],
+                    y=coord_row["y (mm)"],
+                    z=coord_row["z (um)"],
+                    channel=channel,
+                    z_level=z_level,
+                    region=region,
+                    fov_idx=fov,
+                    t=timepoint,
+                )
+
+                self.acquisition_metadata[meta.key] = meta
+
+                # Add region and channel names to the sets
+                self.regions.append(region)
+                self.channel_names.append(channel)
+
+                # Update max_z and max_fov values
+                max_z = max(max_z, z_level)
+                max_fov = max(max_fov, fov)
+
+        # After processing all timepoints, finalize the list of regions and channels
+        self.regions = sorted(set(self.regions))
+        self.channel_names = sorted(set(self.channel_names))
+
+        # Calculate number of timepoints (t), Z levels, and FOVs per region
+        self.num_t = len(self.timepoints)
+        self.num_z = max_z + 1
+        self.num_fovs_per_region = max_fov + 1
+
+        # Set up image parameters based on the first image
+        first_meta = list(self.acquisition_metadata.values())[0]
+        first_image = dask_imread(first_meta.filepath)[0]
+
+        self.dtype = first_image.dtype
+        if len(first_image.shape) == 2:
+            self.input_height, self.input_width = first_image.shape
+        elif len(first_image.shape) == 3:
+            self.input_height, self.input_width = first_image.shape[:2]
+        else:
+            raise ValueError(f"Unexpected image shape: {first_image.shape}")
+        # TODO(colin): further tune the chunk size. Empirically, increasing from
+        # 512x512 to the image size was a huge (25x or more in some cases)
+        # speedup. Is even bigger better?
+        self.chunks = (
+            1,
+            1,
+            1,
+            min(self.input_height, self.CHUNK_SIZE_LIMIT_PX),
+            min(self.input_width, self.CHUNK_SIZE_LIMIT_PX),
+        )
+
+        # Set up final monochrome channels
+        self.monochrome_channels = []
+        for channel in self.channel_names:
+            (t, region, fov, z_level, _) = first_meta.key
+            channel_key = MetaKey(t, region, fov, z_level, channel)
+            channel_image = dask_imread(
+                self.acquisition_metadata[channel_key].filepath
+            )[0]
+            if len(channel_image.shape) == 3 and channel_image.shape[2] == 3:
+                channel = channel.split("_")[0]
+                self.monochrome_channels.extend(
+                    [f"{channel}_R", f"{channel}_G", f"{channel}_B"]
+                )
+            else:
+                self.monochrome_channels.append(channel)
+
+        self.num_c = len(self.monochrome_channels)
+        self.monochrome_colors = [
+            self.get_channel_color(name) for name in self.monochrome_channels
+        ]
+
+        # Print out information about the dataset
+        print(f"Regions: {self.regions}, Channels: {self.channel_names}")
+        print(f"FOV dimensions: {self.input_height}x{self.input_width}")
+        print(f"{self.num_z} Z levels, {self.num_t} Time points")
+        print(f"{self.num_c} Channels: {self.monochrome_channels}")
+        print(f"{len(self.regions)} Regions: {self.regions}")
+        print(f"Number of FOVs per region: {self.num_fovs_per_region}")
+
+    @staticmethod
+    def get_channel_color(channel_name: str) -> int:
+        """Compute the color for display of a given channel name."""
+        color_map = {
+            "405": 0x0000FF,  # Blue
+            "488": 0x00FF00,  # Green
+            "561": 0xFFCF00,  # Yellow
+            "638": 0xFF0000,  # Red
+            "730": 0x770000,  # Dark Red"
+            "_B": 0x0000FF,  # Blue
+            "_G": 0x00FF00,  # Green
+            "_R": 0xFF0000,  # Red
+        }
+        for key, value in color_map.items():
+            if key in channel_name:
+                return value
+        return 0xFFFFFF  # Default to white if no match found
+
+    def get_region_metadata(
+        self, t: int, region: str
+    ) -> dict[MetaKey, AcquisitionMetadata]:
+        """Helper method to get region metadata with consistent filtering."""
+
+        # Filter data with explicit type matching
+        metadata = {
+            key: value
+            for key, value in self.acquisition_metadata.items()
+            if key.t == t and key.region == region
+        }
+
+        if not metadata:
+            available_t = sorted(set(k[0] for k in self.acquisition_metadata.keys()))
+            available_r = sorted(set(k[1] for k in self.acquisition_metadata.keys()))
+            print(f"\nAvailable timepoints in data: {available_t}")
+            print(f"Available regions in data: {available_r}")
+            raise ValueError(f"No data found for timepoint {t}, region {region}")
+
+        return metadata
+
+    def calculate_output_dimensions(
+        self, timepoint: int, region: str
+    ) -> ImagePlaneDims:
+        """Calculate dimensions for the output image.
+
+        Args:
+            timepoint: The timepoint to process
+            region: The region identifier
+
+        TODO(colin): it's weird that this depends on a timepoint and region yet
+        sets global properties of `self`. Refactor to avoid this?
+
+        Returns:
+            tuple: (width_pixels, height_pixels)
+        """
+        region_data = self.get_region_metadata(timepoint, region)
+        # Extract positions
+        self.xy_positions = sorted(
+            (tile_info.x, tile_info.y) for tile_info in region_data.values()
+        )
+        x_positions = sorted(set(x for (x, _) in self.xy_positions))
+        y_positions = sorted(set(y for (_, y) in self.xy_positions))
+
+        if self.parent.use_registration:
+            # Calculate dimensions with registration shifts
+            num_cols = len(x_positions)
+            num_rows = len(y_positions)
+
+            # Handle different scanning patterns
+            if isinstance(self.scan_params, SPatternScanParams):
+                max_h_shift = (
+                    max(
+                        abs(self.scan_params.h_shift[0]),
+                        abs(self.scan_params.h_shift_rev[0]),
+                    ),
+                    max(
+                        abs(self.scan_params.h_shift[1]),
+                        abs(self.scan_params.h_shift_rev[1]),
+                    ),
+                )
+            else:
+                max_h_shift = (
+                    abs(self.scan_params.h_shift[0]),
+                    abs(self.scan_params.h_shift[1]),
+                )
+
+            # Calculate dimensions including overlaps and shifts
+            width_pixels = int(
+                self.input_width
+                + ((num_cols - 1) * (self.input_width - max_h_shift[1]))
+            )
+            width_pixels += abs(
+                (num_rows - 1) * self.scan_params.v_shift[1]
+            )  # Add horizontal shift from vertical registration
+
+            height_pixels = int(
+                self.input_height
+                + ((num_rows - 1) * (self.input_height - self.scan_params.v_shift[0]))
+            )
+            height_pixels += abs(
+                (num_cols - 1) * max_h_shift[0]
+            )  # Add vertical shift from horizontal registration
+
+        else:
+            # Calculate dimensions based on physical coordinates
+            width_mm = (
+                max(x_positions)
+                - min(x_positions)
+                + (self.input_width * self.pixel_size_um / 1000)
+            )
+            height_mm = (
+                max(y_positions)
+                - min(y_positions)
+                + (self.input_height * self.pixel_size_um / 1000)
+            )
+
+            width_pixels = int(np.ceil(width_mm * 1000 / self.pixel_size_um))
+            height_pixels = int(np.ceil(height_mm * 1000 / self.pixel_size_um))
+
+        # Calculate pyramid levels based on dimensions and number of regions
+        if len(self.regions) > 1:
+            rows, columns = self.get_rows_and_columns()
+            max_dimension = max(len(rows), len(columns))
+        else:
+            max_dimension = 1
+
+        self.num_pyramid_levels = max(
+            1,
+            math.ceil(np.log2(max(width_pixels, height_pixels) / 1024 * max_dimension)),
+        )
+
+        return ImagePlaneDims(width_px=width_pixels, height_px=height_pixels)
+
+    def get_rows_and_columns(self) -> tuple[list[str], list[str]]:
+        rows = sorted(set(region[0] for region in self.regions))
+        columns = sorted(set(region[1:] for region in self.regions))
+        return rows, columns

--- a/image_stitcher/parameters_test.py
+++ b/image_stitcher/parameters_test.py
@@ -1,8 +1,25 @@
+import contextlib
+import json
+import math
 import os
+import pathlib
 import tempfile
 import unittest
+from datetime import datetime, timezone
+from typing import Generator
 
-from .parameters import OutputFormat, ScanPattern, StitchingParameters
+import numpy as np
+import pandas as pd
+import skimage.io
+
+from .parameters import (
+    DATETIME_FORMAT,
+    ImagePlaneDims,
+    OutputFormat,
+    ScanPattern,
+    StitchingComputedParameters,
+    StitchingParameters,
+)
 
 
 class ParametersTest(unittest.TestCase):
@@ -31,3 +48,160 @@ class ParametersTest(unittest.TestCase):
             fixture_contents = f.read()
 
         self.assertEqual(contents, fixture_contents)
+
+
+@contextlib.contextmanager
+def temporary_image_directory_params(
+    n_rows: int,
+    n_cols: int,
+    im_size: ImagePlaneDims,
+    channel_names: list[str],
+) -> Generator[StitchingComputedParameters, None, None]:
+    """Set up the files that the computed parameters requires for setup.
+
+    TODO(colin): create tests with multiple timepoints and/or regions and/or z-slices.
+
+    This includes:
+        - images
+        - the coordinates CSV file
+        - the acquisition params file
+    """
+    with tempfile.TemporaryDirectory(delete=True) as d:
+        base_dir = pathlib.Path(d)
+        os.makedirs(base_dir / "0", exist_ok=True)
+        coords_file = base_dir / "0" / "coordinates.csv"
+        acq_params_file = base_dir / "acquisition parameters.json"
+
+        def image_filename(fov: int, channel: str) -> str:
+            mod_channel = channel.replace(" ", "_")
+            return f"R0_{fov}_0_{mod_channel}.tiff"
+
+        def make_fake_image(fov: int) -> np.ndarray:
+            return np.ones((im_size.height_px, im_size.width_px), dtype=np.uint16) * (
+                fov % 65536
+            )
+
+        step_x_mm = 3.2
+        step_y_mm = 3.2
+        coordinates = []
+        fov_counter = 0
+        for r in range(n_rows):
+            for c in range(n_cols):
+                x_pos = c * step_x_mm
+                y_pos = r * step_y_mm
+                coordinates.append(
+                    {
+                        "region": "R0",
+                        "fov": fov_counter,
+                        "z_level": 0,
+                        "x (mm)": x_pos,
+                        "y (mm)": y_pos,
+                        "z (um)": 0,
+                        "time": datetime.now(timezone.utc).strftime(DATETIME_FORMAT),
+                    }
+                )
+                for ch in channel_names:
+                    im_file = base_dir / "0" / image_filename(fov_counter, ch)
+                    skimage.io.imsave(im_file, make_fake_image(fov_counter))
+                fov_counter += 1
+
+        coords = pd.DataFrame(coordinates)
+        coords.to_csv(coords_file, index=False)
+
+        acq_params = {
+            "dx(mm)": step_x_mm,
+            "Nx": n_cols,
+            "dy(mm)": step_y_mm,
+            "Ny": n_rows,
+            "dz(um)": 1.5,
+            "Nz": 1,
+            "dt(s)": 0.0,
+            "Nt": 1,
+            "with AF": False,
+            "with reflection AF": False,
+            "objective": {
+                "magnification": 20.0,
+                "NA": 0.8,
+                "tube_lens_f_mm": 180.0,
+                "name": "20x",
+            },
+            "sensor_pixel_size_um": 7.52,
+            "tube_lens_mm": 180,
+        }
+
+        with open(acq_params_file, "w") as f:
+            json.dump(acq_params, f)
+
+        base_params = StitchingParameters.from_json_file(ParametersTest.fixture_file)
+        base_params.input_folder = str(base_dir)
+        base_params.use_registration = False
+        computed = StitchingComputedParameters(base_params)
+        yield computed
+
+
+class ComputedParametersTest(unittest.TestCase):
+    def test_pixel_size(self) -> None:
+        with temporary_image_directory_params(
+            2,
+            2,
+            ImagePlaneDims(1024, 1024),
+            ["Fluorescence 405 nm Ex", "Fluorescence 488 nm Ex"],
+        ) as computed:
+            self.assertEqual(computed.pixel_size_um, 7.52 / 20)
+
+    def test_channel_names_and_colors(self) -> None:
+        channels = ["Fluorescence 405 nm Ex", "Fluorescence 488 nm Ex"]
+        with temporary_image_directory_params(
+            2,
+            2,
+            ImagePlaneDims(1024, 1024),
+            channels,
+        ) as computed:
+            self.assertEqual(computed.channel_names, channels)
+            self.assertEqual(computed.monochrome_channels, channels)
+            self.assertEqual(computed.monochrome_colors, [0x0000FF, 0x00FF00])
+
+    def test_chunks_and_image_dims(self) -> None:
+        dims = ImagePlaneDims(width_px=1024, height_px=768)
+        with temporary_image_directory_params(
+            2,
+            2,
+            dims,
+            ["Fluorescence 405 nm Ex", "Fluorescence 488 nm Ex"],
+        ) as computed:
+            self.assertEqual(computed.input_height, dims.height_px)
+            self.assertEqual(computed.input_width, dims.width_px)
+            _, _, _, height_chunk, width_chunk = computed.chunks
+            self.assertGreaterEqual(height_chunk, dims.height_px)
+            self.assertGreaterEqual(width_chunk, dims.width_px)
+
+    def test_output_dims(self) -> None:
+        dims = ImagePlaneDims(width_px=1024, height_px=768)
+        n_rows = 2
+        n_cols = 2
+        with temporary_image_directory_params(
+            n_rows,
+            n_cols,
+            dims,
+            ["Fluorescence 405 nm Ex", "Fluorescence 488 nm Ex"],
+        ) as computed:
+            output_dims = computed.calculate_output_dimensions(timepoint=0, region="R0")
+            px_size_um = 7.52 / 20
+            self.assertEqual(
+                output_dims.height_px,
+                int(
+                    math.ceil(
+                        ((n_rows - 1) * 3.2 * 1000 + dims.height_px * px_size_um)
+                        / px_size_um
+                    )
+                ),
+            )
+            self.assertEqual(
+                output_dims.width_px,
+                int(
+                    math.ceil(
+                        ((n_cols - 1) * 3.2 * 1000 + dims.width_px * px_size_um)
+                        / px_size_um
+                    )
+                ),
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "mypy>=1.14.1",
+    "pandas-stubs>=2.2.3.241126",
     "ruff>=0.9.1",
 ]
 
@@ -20,3 +21,7 @@ disallow_untyped_defs = true
 strict_optional = true
 implicit_optional = false
 warn_return_any = true
+
+[[tool.mypy.overrides]]
+module = ["dask_image.*"]
+ignore_missing_imports = true

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pandas-stubs" },
     { name = "ruff" },
 ]
 
@@ -34,6 +35,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.14.1" },
+    { name = "pandas-stubs", specifier = ">=2.2.3.241126" },
     { name = "ruff", specifier = ">=0.9.1" },
 ]
 
@@ -69,6 +71,57 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
+]
+
+[[package]]
+name = "numpy"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/fdbf6a7871703df6160b5cf3dd774074b086d278172285c52c2758b76305/numpy-2.2.1.tar.gz", hash = "sha256:45681fd7128c8ad1c379f0ca0776a8b0c6583d2f69889ddac01559dfe4390918", size = 20227662 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/12/b928871c570d4a87ab13d2cc19f8817f17e340d5481621930e76b80ffb7d/numpy-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:694f9e921a0c8f252980e85bce61ebbd07ed2b7d4fa72d0e4246f2f8aa6642ab", size = 20909861 },
+    { url = "https://files.pythonhosted.org/packages/3d/c3/59df91ae1d8ad7c5e03efd63fd785dec62d96b0fe56d1f9ab600b55009af/numpy-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3683a8d166f2692664262fd4900f207791d005fb088d7fdb973cc8d663626faa", size = 14095776 },
+    { url = "https://files.pythonhosted.org/packages/af/4e/8ed5868efc8e601fb69419644a280e9c482b75691466b73bfaab7d86922c/numpy-2.2.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:780077d95eafc2ccc3ced969db22377b3864e5b9a0ea5eb347cc93b3ea900315", size = 5126239 },
+    { url = "https://files.pythonhosted.org/packages/1a/74/dd0bbe650d7bc0014b051f092f2de65e34a8155aabb1287698919d124d7f/numpy-2.2.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:55ba24ebe208344aa7a00e4482f65742969a039c2acfcb910bc6fcd776eb4355", size = 6659296 },
+    { url = "https://files.pythonhosted.org/packages/7f/11/4ebd7a3f4a655764dc98481f97bd0a662fb340d1001be6050606be13e162/numpy-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b1d07b53b78bf84a96898c1bc139ad7f10fda7423f5fd158fd0f47ec5e01ac7", size = 14047121 },
+    { url = "https://files.pythonhosted.org/packages/7f/a7/c1f1d978166eb6b98ad009503e4d93a8c1962d0eb14a885c352ee0276a54/numpy-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5062dc1a4e32a10dc2b8b13cedd58988261416e811c1dc4dbdea4f57eea61b0d", size = 16096599 },
+    { url = "https://files.pythonhosted.org/packages/3d/6d/0e22afd5fcbb4d8d0091f3f46bf4e8906399c458d4293da23292c0ba5022/numpy-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:fce4f615f8ca31b2e61aa0eb5865a21e14f5629515c9151850aa936c02a1ee51", size = 15243932 },
+    { url = "https://files.pythonhosted.org/packages/03/39/e4e5832820131ba424092b9610d996b37e5557180f8e2d6aebb05c31ae54/numpy-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:67d4cda6fa6ffa073b08c8372aa5fa767ceb10c9a0587c707505a6d426f4e046", size = 17861032 },
+    { url = "https://files.pythonhosted.org/packages/5f/8a/3794313acbf5e70df2d5c7d2aba8718676f8d054a05abe59e48417fb2981/numpy-2.2.1-cp312-cp312-win32.whl", hash = "sha256:32cb94448be47c500d2c7a95f93e2f21a01f1fd05dd2beea1ccd049bb6001cd2", size = 6274018 },
+    { url = "https://files.pythonhosted.org/packages/17/c1/c31d3637f2641e25c7a19adf2ae822fdaf4ddd198b05d79a92a9ce7cb63e/numpy-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:ba5511d8f31c033a5fcbda22dd5c813630af98c70b2661f2d2c654ae3cdfcfc8", size = 12613843 },
+    { url = "https://files.pythonhosted.org/packages/20/d6/91a26e671c396e0c10e327b763485ee295f5a5a7a48c553f18417e5a0ed5/numpy-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f1d09e520217618e76396377c81fba6f290d5f926f50c35f3a5f72b01a0da780", size = 20896464 },
+    { url = "https://files.pythonhosted.org/packages/8c/40/5792ccccd91d45e87d9e00033abc4f6ca8a828467b193f711139ff1f1cd9/numpy-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3ecc47cd7f6ea0336042be87d9e7da378e5c7e9b3c8ad0f7c966f714fc10d821", size = 14111350 },
+    { url = "https://files.pythonhosted.org/packages/c0/2a/fb0a27f846cb857cef0c4c92bef89f133a3a1abb4e16bba1c4dace2e9b49/numpy-2.2.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f419290bc8968a46c4933158c91a0012b7a99bb2e465d5ef5293879742f8797e", size = 5111629 },
+    { url = "https://files.pythonhosted.org/packages/eb/e5/8e81bb9d84db88b047baf4e8b681a3e48d6390bc4d4e4453eca428ecbb49/numpy-2.2.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:5b6c390bfaef8c45a260554888966618328d30e72173697e5cabe6b285fb2348", size = 6645865 },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/a90ceb191dd2f9e2897c69dde93ccc2d57dd21ce2acbd7b0333e8eea4e8d/numpy-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:526fc406ab991a340744aad7e25251dd47a6720a685fa3331e5c59fef5282a59", size = 14043508 },
+    { url = "https://files.pythonhosted.org/packages/f1/5a/e572284c86a59dec0871a49cd4e5351e20b9c751399d5f1d79628c0542cb/numpy-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f74e6fdeb9a265624ec3a3918430205dff1df7e95a230779746a6af78bc615af", size = 16094100 },
+    { url = "https://files.pythonhosted.org/packages/0c/2c/a79d24f364788386d85899dd280a94f30b0950be4b4a545f4fa4ed1d4ca7/numpy-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:53c09385ff0b72ba79d8715683c1168c12e0b6e84fb0372e97553d1ea91efe51", size = 15239691 },
+    { url = "https://files.pythonhosted.org/packages/cf/79/1e20fd1c9ce5a932111f964b544facc5bb9bde7865f5b42f00b4a6a9192b/numpy-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f3eac17d9ec51be534685ba877b6ab5edc3ab7ec95c8f163e5d7b39859524716", size = 17856571 },
+    { url = "https://files.pythonhosted.org/packages/be/5b/cc155e107f75d694f562bdc84a26cc930569f3dfdfbccb3420b626065777/numpy-2.2.1-cp313-cp313-win32.whl", hash = "sha256:9ad014faa93dbb52c80d8f4d3dcf855865c876c9660cb9bd7553843dd03a4b1e", size = 6270841 },
+    { url = "https://files.pythonhosted.org/packages/44/be/0e5cd009d2162e4138d79a5afb3b5d2341f0fe4777ab6e675aa3d4a42e21/numpy-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:164a829b6aacf79ca47ba4814b130c4020b202522a93d7bff2202bfb33b61c60", size = 12606618 },
+    { url = "https://files.pythonhosted.org/packages/a8/87/04ddf02dd86fb17c7485a5f87b605c4437966d53de1e3745d450343a6f56/numpy-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4dfda918a13cc4f81e9118dea249e192ab167a0bb1966272d5503e39234d694e", size = 20921004 },
+    { url = "https://files.pythonhosted.org/packages/6e/3e/d0e9e32ab14005425d180ef950badf31b862f3839c5b927796648b11f88a/numpy-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:733585f9f4b62e9b3528dd1070ec4f52b8acf64215b60a845fa13ebd73cd0712", size = 14119910 },
+    { url = "https://files.pythonhosted.org/packages/b5/5b/aa2d1905b04a8fb681e08742bb79a7bddfc160c7ce8e1ff6d5c821be0236/numpy-2.2.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:89b16a18e7bba224ce5114db863e7029803c179979e1af6ad6a6b11f70545008", size = 5153612 },
+    { url = "https://files.pythonhosted.org/packages/ce/35/6831808028df0648d9b43c5df7e1051129aa0d562525bacb70019c5f5030/numpy-2.2.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:676f4eebf6b2d430300f1f4f4c2461685f8269f94c89698d832cdf9277f30b84", size = 6668401 },
+    { url = "https://files.pythonhosted.org/packages/b1/38/10ef509ad63a5946cc042f98d838daebfe7eaf45b9daaf13df2086b15ff9/numpy-2.2.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27f5cdf9f493b35f7e41e8368e7d7b4bbafaf9660cba53fb21d2cd174ec09631", size = 14014198 },
+    { url = "https://files.pythonhosted.org/packages/df/f8/c80968ae01df23e249ee0a4487fae55a4c0fe2f838dfe9cc907aa8aea0fa/numpy-2.2.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1ad395cf254c4fbb5b2132fee391f361a6e8c1adbd28f2cd8e79308a615fe9d", size = 16076211 },
+    { url = "https://files.pythonhosted.org/packages/09/69/05c169376016a0b614b432967ac46ff14269eaffab80040ec03ae1ae8e2c/numpy-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:08ef779aed40dbc52729d6ffe7dd51df85796a702afbf68a4f4e41fafdc8bda5", size = 15220266 },
+    { url = "https://files.pythonhosted.org/packages/f1/ff/94a4ce67ea909f41cf7ea712aebbe832dc67decad22944a1020bb398a5ee/numpy-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:26c9c4382b19fcfbbed3238a14abf7ff223890ea1936b8890f058e7ba35e8d71", size = 17852844 },
+    { url = "https://files.pythonhosted.org/packages/46/72/8a5dbce4020dfc595592333ef2fbb0a187d084ca243b67766d29d03e0096/numpy-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:93cf4e045bae74c90ca833cba583c14b62cb4ba2cba0abd2b141ab52548247e2", size = 6326007 },
+    { url = "https://files.pythonhosted.org/packages/7b/9c/4fce9cf39dde2562584e4cfd351a0140240f82c0e3569ce25a250f47037d/numpy-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:bff7d8ec20f5f42607599f9994770fa65d76edca264a87b5e4ea5629bce12268", size = 12693107 },
+]
+
+[[package]]
+name = "pandas-stubs"
+version = "2.2.3.241126"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "types-pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/86/93c545d149c3e1fe1c4c55478cc3a69859d0ea3467e1d9892e9eb28cb1e7/pandas_stubs-2.2.3.241126.tar.gz", hash = "sha256:cf819383c6d9ae7d4dabf34cd47e1e45525bb2f312e6ad2939c2c204cb708acd", size = 104204 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/ab/ed42acf15bab2e86e5c49fad4aa038315233c4c2d22f41b49faa4d837516/pandas_stubs-2.2.3.241126-py3-none-any.whl", hash = "sha256:74aa79c167af374fe97068acc90776c0ebec5266a6e5c69fe11e9c2cf51f2267", size = 158280 },
 ]
 
 [[package]]
@@ -147,6 +200,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/39/c6/fe45f3eb27e3948b41a305d8b768e949bf6a39310e9df73f6c576d7f1d9f/ruff-0.9.1-py3-none-win32.whl", hash = "sha256:46ebf5cc106cf7e7378ca3c28ce4293b61b449cd121b98699be727d40b79ba72", size = 8819750 },
     { url = "https://files.pythonhosted.org/packages/38/8d/580db77c3b9d5c3d9479e55b0b832d279c30c8f00ab0190d4cd8fc67831c/ruff-0.9.1-py3-none-win_amd64.whl", hash = "sha256:342a824b46ddbcdddd3abfbb332fa7fcaac5488bf18073e841236aadf4ad5c19", size = 9701331 },
     { url = "https://files.pythonhosted.org/packages/b2/94/0498cdb7316ed67a1928300dd87d659c933479f44dec51b4f62bfd1f8028/ruff-0.9.1-py3-none-win_arm64.whl", hash = "sha256:1cd76c7f9c679e6e8f2af8f778367dca82b95009bc7b1a85a47f1521ae524fa7", size = 9145708 },
+]
+
+[[package]]
+name = "types-pytz"
+version = "2024.2.0.20241221"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/26/516311b02b5a215e721155fb65db8a965d061372e388d6125ebce8d674b0/types_pytz-2024.2.0.20241221.tar.gz", hash = "sha256:06d7cde9613e9f7504766a0554a270c369434b50e00975b3a4a0f6eed0f2c1a9", size = 10213 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/db/c92ca6920cccd9c2998b013601542e2ac5e59bc805bcff94c94ad254b7df/types_pytz-2024.2.0.20241221-py3-none-any.whl", hash = "sha256:8fc03195329c43637ed4f593663df721fef919b60a969066e22606edf0b53ad5", size = 10008 },
 ]
 
 [[package]]


### PR DESCRIPTION
There's a bunch of parameters used in the stitching code that are neither part of the image processing code per se, nor required as user inputs. Formerly, these were just set up as extra properties on the Stitcher class in a bunch of different functions (I started from: https://github.com/sohamazing/image-stitcher/blob/622b06e5a9151c35453ea03ffc9e1b607547159c/stitcher.py)

To make it clearer what these all are supposed to be, test their computation, and clean up the large Sticher class, I've moved them out into their own parameters dataclass. To safeguard against using the default values that were there before but never intended to be actually used, I lightly restructured it so that the fields use `field(init=False)` for the default, which will raise an attribute if a later bug means that we didn't initialize a field that we expected to be initialized. (It might be worth doing additional refactoring later to avoid this existing late initalization pattern altogether.)

This also includes a change to change the dask array chunk size to ensure that it's at least the size of a single image plane. In my testing, this was a very large speedup (up to 25x for the largest image I tested, which was 400 fov) for image planes that can fit in memory and thus were being chunked needlessly.

Finally, I added some basic tests for computing some of the parameters to make it easier to make changes confidently in the future.

Tested by:
- `./dev/autofix_lint.sh`
- `./dev/format.sh`
- `./dev/type_check.sh`
- `uv run python -m unittest image_stitcher.parameters_test`