### PR TITLE
Switch from `print` to `logging`

### DIFF
--- a/image_stitcher/parameters.py
+++ b/image_stitcher/parameters.py
@@ -90,6 +90,9 @@ class StitchingParameters(
     merge_hcs_regions: bool = False
     """Merge HCS regions (wells) to create full wellplate HCS output."""
 
+    verbose: bool = False
+    """Show debug-level logging."""
+
     def __post_init__(self) -> None:
         """Validate and process parameters after initialization."""
         # Convert relative path to absolute

--- a/image_stitcher/stitcher_cli.py
+++ b/image_stitcher/stitcher_cli.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 
 from pydantic_settings import CliApp
@@ -8,6 +9,8 @@ from image_stitcher.stitcher import Stitcher
 
 def main(args: list[str]) -> None:
     params = CliApp.run(StitchingParameters, cli_args=args)
+    log_level = logging.DEBUG if params.verbose else logging.INFO
+    logging.basicConfig(level=log_level)
     Stitcher(params).run()
 
 

--- a/image_stitcher/stitcher_gui.py
+++ b/image_stitcher/stitcher_gui.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from typing import Any, cast
 
@@ -364,7 +365,7 @@ class StitchingGUI(QWidget):
             napari.run()
         except Exception as e:
             QMessageBox.critical(self, "Error Opening in Napari", str(e))
-            print(f"An error occurred while opening output in Napari: {e}")
+            logging.error(f"An error occurred while opening output in Napari: {e}")
 
     def extractWavelength(self, name: str) -> str | None:
         # Split the string and find the wavelength number immediately after "Fluorescence"
@@ -390,6 +391,7 @@ class StitchingGUI(QWidget):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     app = QApplication(sys.argv)
     gui = StitchingGUI()
     gui.show()


### PR DESCRIPTION
This lets our output be slightly less spammy unless we provide the `--verbose` flag on the CLI (in which case we our own debug output + some third-party image library verbose output too).