### PR TITLE
Add a test for the stitcher

### DIFF
--- a/dev/run_tests.sh
+++ b/dev/run_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+uv run python -m unittest \
+    image_stitcher.parameters_test \
+    image_stitcher.stitcher_test

--- a/image_stitcher/parameters.py
+++ b/image_stitcher/parameters.py
@@ -11,8 +11,7 @@ from typing import Annotated, Any, ClassVar, NamedTuple, assert_never
 import numpy as np
 import pandas as pd
 from dask_image.imread import imread as dask_imread
-from pydantic import AfterValidator
-from pydantic_settings import BaseSettings
+from pydantic import AfterValidator, BaseModel
 
 DATETIME_FORMAT = "%Y-%m-%d_%H-%M-%S.%f"
 
@@ -44,9 +43,7 @@ def z_non_negative(num: int) -> int:
 
 
 class StitchingParameters(
-    BaseSettings,
-    cli_parse_args=True,
-    cli_prog_name="image_stitcher",
+    BaseModel,
     use_attribute_docstrings=True,
 ):
     """Parameters for microscopy image stitching operations."""

--- a/image_stitcher/parameters_test.py
+++ b/image_stitcher/parameters_test.py
@@ -1,143 +1,39 @@
-import contextlib
-import json
 import math
-import os
-import pathlib
 import tempfile
 import unittest
-from datetime import datetime, timezone
-from typing import Generator
 
-import numpy as np
-import pandas as pd
-import skimage.io
+from image_stitcher.testutil import (
+    PARAMETERS_FIXTURE_FILE,
+    temporary_image_directory_params,
+)
 
 from .parameters import (
-    DATETIME_FORMAT,
     ImagePlaneDims,
     OutputFormat,
     ScanPattern,
-    StitchingComputedParameters,
     StitchingParameters,
 )
 
 
 class ParametersTest(unittest.TestCase):
-    fixture_file = os.path.join(
-        os.path.dirname(os.path.dirname(__file__)),
-        "test_fixtures",
-        "parameters_test",
-        "parameters.json",
-    )
-
     def test_parsing(self) -> None:
-        params = StitchingParameters.from_json_file(self.fixture_file)
+        params = StitchingParameters.from_json_file(str(PARAMETERS_FIXTURE_FILE))
         self.assertEqual(params.scan_pattern, ScanPattern.unidirectional)
         self.assertEqual(params.output_format, OutputFormat.ome_zarr)
         self.assertEqual(params.input_folder, "/")
 
     def test_roundtrip(self) -> None:
         with tempfile.NamedTemporaryFile("w+", delete=True) as f:
-            params = StitchingParameters.from_json_file(self.fixture_file)
+            params = StitchingParameters.from_json_file(str(PARAMETERS_FIXTURE_FILE))
             params.to_json_file(f.name)
             f.flush()
             f.seek(0)
             contents = f.read()
 
-        with open(self.fixture_file) as f:
+        with open(PARAMETERS_FIXTURE_FILE) as f:
             fixture_contents = f.read()
 
         self.assertEqual(contents, fixture_contents)
-
-
-@contextlib.contextmanager
-def temporary_image_directory_params(
-    n_rows: int,
-    n_cols: int,
-    im_size: ImagePlaneDims,
-    channel_names: list[str],
-    name: str = "image_inputs",
-) -> Generator[StitchingComputedParameters, None, None]:
-    """Set up the files that the computed parameters requires for setup.
-
-    TODO(colin): create tests with multiple timepoints and/or regions and/or z-slices.
-
-    This includes:
-        - images
-        - the coordinates CSV file
-        - the acquisition params file
-    """
-    with tempfile.TemporaryDirectory(delete=True) as d:
-        base_dir = pathlib.Path(d) / name
-        os.makedirs(base_dir / "0", exist_ok=True)
-        coords_file = base_dir / "0" / "coordinates.csv"
-        acq_params_file = base_dir / "acquisition parameters.json"
-
-        def image_filename(fov: int, channel: str) -> str:
-            mod_channel = channel.replace(" ", "_")
-            return f"R0_{fov}_0_{mod_channel}.tiff"
-
-        def make_fake_image(fov: int) -> np.ndarray:
-            return np.ones((im_size.height_px, im_size.width_px), dtype=np.uint16) * (
-                fov % 65536
-            )
-
-        step_x_mm = 3.2
-        step_y_mm = 3.2
-        coordinates = []
-        fov_counter = 0
-        for r in range(n_rows):
-            for c in range(n_cols):
-                x_pos = c * step_x_mm
-                y_pos = r * step_y_mm
-                coordinates.append(
-                    {
-                        "region": "R0",
-                        "fov": fov_counter,
-                        "z_level": 0,
-                        "x (mm)": x_pos,
-                        "y (mm)": y_pos,
-                        "z (um)": 0,
-                        "time": datetime.now(timezone.utc).strftime(DATETIME_FORMAT),
-                    }
-                )
-                for ch in channel_names:
-                    im_file = base_dir / "0" / image_filename(fov_counter, ch)
-                    skimage.io.imsave(im_file, make_fake_image(fov_counter))
-                fov_counter += 1
-
-        coords = pd.DataFrame(coordinates)
-        coords.to_csv(coords_file, index=False)
-
-        acq_params = {
-            "dx(mm)": step_x_mm,
-            "Nx": n_cols,
-            "dy(mm)": step_y_mm,
-            "Ny": n_rows,
-            "dz(um)": 1.5,
-            "Nz": 1,
-            "dt(s)": 0.0,
-            "Nt": 1,
-            "with AF": False,
-            "with reflection AF": False,
-            "objective": {
-                "magnification": 20.0,
-                "NA": 0.8,
-                "tube_lens_f_mm": 180.0,
-                "name": "20x",
-            },
-            "sensor_pixel_size_um": 7.52,
-            "tube_lens_mm": 180,
-        }
-
-        with open(acq_params_file, "w") as f:
-            json.dump(acq_params, f)
-
-        base_params = StitchingParameters.from_json_file(ParametersTest.fixture_file)
-        base_params.input_folder = str(base_dir)
-        base_params.use_registration = False
-        computed = StitchingComputedParameters(base_params)
-        yield computed
 
 
 class ComputedParametersTest(unittest.TestCase):

--- a/image_stitcher/stitcher_test.py
+++ b/image_stitcher/stitcher_test.py
@@ -1,0 +1,45 @@
+import unittest
+
+from ome_zarr.io import parse_url
+from ome_zarr.reader import Reader
+
+from .parameters import ImagePlaneDims
+from .stitcher import ProgressCallbacks, Stitcher
+from .testutil import temporary_image_directory_params
+
+
+class StitcherTest(unittest.TestCase):
+    def test_basic_stage_stitching(self) -> None:
+        with temporary_image_directory_params(
+            n_rows=3,
+            n_cols=3,
+            # Exactly non-overlapping images aligned in a grid.
+            im_size=ImagePlaneDims(1000, 1000),
+            channel_names=["DAPI", "FITC", "TRITC"],
+            step_mm=(1.0, 1.0),
+            sensor_pixel_size_µm=20.0,
+            magnification=20.0,
+        ) as params:
+            output_filename = None
+
+            def finished_saving(output_path: str, _dtype: object) -> None:
+                nonlocal output_filename
+                output_filename = output_path
+
+            callbacks = ProgressCallbacks.no_op()
+            callbacks.finished_saving = finished_saving
+            stitcher = Stitcher(params.parent, callbacks)
+            stitcher.run()
+            self.assertIsNotNone(output_filename)
+
+            im = next(Reader(parse_url(output_filename))()).data[0]
+            print(im[0, 0, 0, 0, 1])
+            self.assertEqual(im.shape, (1, 3, 1, 3000, 3000))
+            self.assertEqual(im[0, 0, 0, 0, 0].compute(), 0)
+            self.assertEqual(im[0, 0, 0, 1000, 0].compute(), 3)
+            self.assertEqual(im[0, 0, 0, 1500, 0].compute(), 3)
+            self.assertEqual(im[0, 0, 0, 2000, 0].compute(), 6)
+            self.assertEqual(im[0, 0, 0, 0, 1000].compute(), 1)
+            self.assertEqual(im[0, 0, 0, 0, 1500].compute(), 1)
+            self.assertEqual(im[0, 0, 0, 0, 2000].compute(), 2)
+            self.assertEqual(im[0, 0, 0, 2999, 2999].compute(), 8)

--- a/image_stitcher/testutil.py
+++ b/image_stitcher/testutil.py
@@ -1,0 +1,117 @@
+import contextlib
+import json
+import os
+import pathlib
+import tempfile
+from datetime import datetime, timezone
+from typing import Generator
+
+import numpy as np
+import pandas as pd
+import skimage
+
+from .parameters import (
+    DATETIME_FORMAT,
+    ImagePlaneDims,
+    StitchingComputedParameters,
+    StitchingParameters,
+)
+
+PARAMETERS_FIXTURE_FILE = (
+    pathlib.Path(__file__).parent.parent
+    / "test_fixtures"
+    / "parameters_test"
+    / "parameters.json"
+)
+
+
+@contextlib.contextmanager
+def temporary_image_directory_params(
+    n_rows: int,
+    n_cols: int,
+    im_size: ImagePlaneDims,
+    channel_names: list[str],
+    name: str = "image_inputs",
+    step_mm: tuple[float, float] = (3.2, 3.2),
+    sensor_pixel_size_µm: float = 7.52,
+    magnification: float = 20.0,
+) -> Generator[StitchingComputedParameters, None, None]:
+    """Set up the files that the computed parameters requires for setup.
+
+    TODO(colin): create tests with multiple timepoints and/or regions and/or z-slices.
+
+    This includes:
+        - images
+        - the coordinates CSV file
+        - the acquisition params file
+    """
+    with tempfile.TemporaryDirectory(delete=True) as d:
+        base_dir = pathlib.Path(d) / name
+        os.makedirs(base_dir / "0", exist_ok=True)
+        coords_file = base_dir / "0" / "coordinates.csv"
+        acq_params_file = base_dir / "acquisition parameters.json"
+
+        def image_filename(fov: int, channel: str) -> str:
+            mod_channel = channel.replace(" ", "_")
+            return f"R0_{fov}_0_{mod_channel}.tiff"
+
+        def make_fake_image(fov: int) -> np.ndarray:
+            return np.ones((im_size.height_px, im_size.width_px), dtype=np.uint16) * (
+                fov % 65536
+            )
+
+        step_x_mm, step_y_mm = step_mm
+        coordinates = []
+        fov_counter = 0
+        for r in range(n_rows):
+            for c in range(n_cols):
+                x_pos = c * step_x_mm
+                y_pos = r * step_y_mm
+                coordinates.append(
+                    {
+                        "region": "R0",
+                        "fov": fov_counter,
+                        "z_level": 0,
+                        "x (mm)": x_pos,
+                        "y (mm)": y_pos,
+                        "z (um)": 0,
+                        "time": datetime.now(timezone.utc).strftime(DATETIME_FORMAT),
+                    }
+                )
+                for ch in channel_names:
+                    im_file = base_dir / "0" / image_filename(fov_counter, ch)
+                    skimage.io.imsave(im_file, make_fake_image(fov_counter))
+                fov_counter += 1
+
+        coords = pd.DataFrame(coordinates)
+        coords.to_csv(coords_file, index=False)
+
+        acq_params = {
+            "dx(mm)": step_x_mm,
+            "Nx": n_cols,
+            "dy(mm)": step_y_mm,
+            "Ny": n_rows,
+            "dz(um)": 1.5,
+            "Nz": 1,
+            "dt(s)": 0.0,
+            "Nt": 1,
+            "with AF": False,
+            "with reflection AF": False,
+            "objective": {
+                "magnification": magnification,
+                "NA": 0.8,
+                "tube_lens_f_mm": 180.0,
+                "name": "20x",
+            },
+            "sensor_pixel_size_um": sensor_pixel_size_μm,
+            "tube_lens_mm": 180,
+        }
+
+        with open(acq_params_file, "w") as f:
+            json.dump(acq_params, f)
+
+        base_params = StitchingParameters.from_json_file(str(PARAMETERS_FIXTURE_FILE))
+        base_params.input_folder = str(base_dir)
+        base_params.use_registration = False
+        computed = StitchingComputedParameters(base_params)
+        yield computed

--- a/test_fixtures/parameters_test/parameters.json
+++ b/test_fixtures/parameters_test/parameters.json
@@ -8,5 +8,6 @@
   "dynamic_registration": false,
   "scan_pattern": "Unidirectional",
   "merge_timepoints": false,
-  "merge_hcs_regions": false
+  "merge_hcs_regions": false,
+  "verbose": false
 }


### PR DESCRIPTION
This commit sets up a set of fake images to stitch and tests stitching them together in a perfectly side-to-side but nonoverlapping grid.

I also added some other fixes because I broke the tests in the last stitcher commit by switching the parameters class to BaseSettings instead of BaseModel (I switched it back.)

Tested by:
- `./dev/run_tests.sh`
- `./dev/autofix_lint.sh`
- `./dev/format.sh`
- `./dev/type_check.sh`