### PR TITLE
Use skimage for image reading direct to numpy arrays instead of dask

### DIFF
--- a/image_stitcher/stitcher.py
+++ b/image_stitcher/stitcher.py
@@ -10,6 +10,7 @@ import dask.array as da
 import numpy as np
 import ome_zarr
 import psutil
+import skimage
 import zarr
 from aicsimageio import types as aics_types
 from aicsimageio.writers import OmeTiffWriter, OmeZarrWriter
@@ -282,7 +283,7 @@ class Stitcher:
         # Process each tile with progress tracking
         for key, tile_info in region_metadata.items():
             t, _, _, z_level, channel = key
-            tile = dask_imread(tile_info.filepath)[0]
+            tile = skimage.io.imread(tile_info.filepath)
 
             if self.params.use_registration:
                 col_index = self.computed_parameters.x_positions.index(tile_info.x)
@@ -981,6 +982,7 @@ class Stitcher:
 
                 # Stitch region
                 self.callbacks.starting_stitching()
+
                 stitched_region = self.stitch_region(timepoint, region)
                 with debug_timing("rechunking"):
                     if isinstance(stitched_region, da.Array):


### PR DESCRIPTION
When reading the raw images from disk, we're reading single fields of view for a single region and timepoint, so we should not have to worry about images not fitting into memory, and we can cut out dask from this step. This both makes profiling easier and also in my testing cuts off about 1s from the 8x8 field of view benchmark I've been using (which is now down in the 10-11s range).

Tested by:
- `./dev/run_tests.sh`