### PR TITLE
Provide a `name` when calling `da.from_array`

### DIFF
--- a/image_stitcher/stitcher.py
+++ b/image_stitcher/stitcher.py
@@ -991,6 +991,7 @@ class Stitcher:
                         dask_stitched_region = da.from_array(
                             stitched_region,
                             chunks=self.computed_parameters.chunks,
+                            name=f"stitched:t={timepoint},r={region}",
                         )
 
                 # Save the region


### PR DESCRIPTION
In a previous commit, I found a small speedup for data that fits in memroy by using numpy arrays in this case rather than dask ones. Interestingly it's faster (TBD under what full range of conditions and why) to then convert this to a dask array before writing out to zarr.

It turns out we can speed up this conversion to a dask array by multiple seconds by providing a `name=` parameter to the `from_array` function. If you don't provide a name, it creates one by hashing the data, which for giant stitched images can take several seconds.

After this change, the 8x8fov test case I've been using is down to ~12s (from ~16 before this change and the previous one).

Tested by:
- `./dev/autofix_lint.sh`
- `./dev/format.sh`
- `./dev/type_check.sh`
- `./dev/run_tests.sh`