### PR TITLE
Use a zarr, disk-backed impl for large images

### DIFF
--- a/image_stitcher/parameters.py
+++ b/image_stitcher/parameters.py
@@ -91,9 +91,18 @@ class StitchingParameters(
     verbose: bool = False
     """Show debug-level logging."""
 
-    def __post_init__(self) -> None:
+    force_stitch_to_disk: bool = False
+    """If true, force using a disk-backed stitching implementation regardless of input size.
+
+    (Otherwise, we use a disk-based implementation only if the full image
+    doesn't fit into memory.)
+
+    This can be useful for debugging and testing, or if you want to keep memory
+    usage as low as possible, at the cost of some processing speed.
+    """
+
+    def model_post_init(self, __context: Any) -> None:
         """Validate and process parameters after initialization."""
-        # Convert relative path to absolute
         self.input_folder = os.path.abspath(self.input_folder)
 
     @property

--- a/image_stitcher/stitcher_test.py
+++ b/image_stitcher/stitcher_test.py
@@ -42,3 +42,38 @@ class StitcherTest(unittest.TestCase):
             self.assertEqual(im[0, 0, 0, 0, 1500].compute(), 1)
             self.assertEqual(im[0, 0, 0, 0, 2000].compute(), 2)
             self.assertEqual(im[0, 0, 0, 2999, 2999].compute(), 8)
+
+    def test_basic_stage_stitching_zarr_backed(self) -> None:
+        with temporary_image_directory_params(
+            n_rows=3,
+            n_cols=3,
+            # Exactly non-overlapping images aligned in a grid.
+            im_size=ImagePlaneDims(1000, 1000),
+            channel_names=["DAPI", "FITC", "TRITC"],
+            step_mm=(1.0, 1.0),
+            sensor_pixel_size_µm=20.0,
+            magnification=20.0,
+            disk_based_output_arr=True,
+        ) as params:
+            output_filename = None
+
+            def finished_saving(output_path: str, _dtype: object) -> None:
+                nonlocal output_filename
+                output_filename = output_path
+
+            callbacks = ProgressCallbacks.no_op()
+            callbacks.finished_saving = finished_saving
+            stitcher = Stitcher(params.parent, callbacks)
+            stitcher.run()
+            self.assertIsNotNone(output_filename)
+
+            im = next(Reader(parse_url(output_filename))()).data[0]
+            self.assertEqual(im.shape, (1, 3, 1, 3000, 3000))
+            self.assertEqual(im[0, 0, 0, 0, 0].compute(), 0)
+            self.assertEqual(im[0, 0, 0, 1000, 0].compute(), 3)
+            self.assertEqual(im[0, 0, 0, 1500, 0].compute(), 3)
+            self.assertEqual(im[0, 0, 0, 2000, 0].compute(), 6)
+            self.assertEqual(im[0, 0, 0, 0, 1000].compute(), 1)
+            self.assertEqual(im[0, 0, 0, 0, 1500].compute(), 1)
+            self.assertEqual(im[0, 0, 0, 0, 2000].compute(), 2)
+            self.assertEqual(im[0, 0, 0, 2999, 2999].compute(), 8)

--- a/image_stitcher/testutil.py
+++ b/image_stitcher/testutil.py
@@ -35,6 +35,7 @@ def temporary_image_directory_params(
     step_mm: tuple[float, float] = (3.2, 3.2),
     sensor_pixel_size_µm: float = 7.52,
     magnification: float = 20.0,
+    disk_based_output_arr: bool = False,
 ) -> Generator[StitchingComputedParameters, None, None]:
     """Set up the files that the computed parameters requires for setup.
 
@@ -111,6 +112,8 @@ def temporary_image_directory_params(
             json.dump(acq_params, f)
 
         base_params = StitchingParameters.from_json_file(str(PARAMETERS_FIXTURE_FILE))
+        if disk_based_output_arr:
+            base_params.force_stitch_to_disk = True
         base_params.input_folder = str(base_dir)
         base_params.use_registration = False
         computed = StitchingComputedParameters(base_params)

--- a/test_fixtures/parameters_test/parameters.json
+++ b/test_fixtures/parameters_test/parameters.json
@@ -9,5 +9,6 @@
   "scan_pattern": "Unidirectional",
   "merge_timepoints": false,
   "merge_hcs_regions": false,
-  "verbose": false
+  "verbose": false,
+  "force_stitch_to_disk": false
 }


### PR DESCRIPTION
This commit makes it so that we use a zarr array backed by disk to do stitching in cases where the image is too large to fit into memory (based upon pstats's estimation of how much free memory there is as well as a heuristic multiplier of the expected memory usage of the output array). Since this uses disk for some operations, we expect some parts will be slower, and to mitigate this, we ensure that the output array ends up being level 0 of the zarr pyramid output, so that we don't have to make a second copy to disk.

I added a parameter to the input parameters that lets you force using this disk mode (which is useful for testing / profiling / debugging, or potentially for limiting production memory usage).

Tested by:
- `./dev/run_tests.sh`
- lots of manual benchmarking on images of different sizes using the CLI