### PR TITLE
Add setup and install scripts for the GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,32 @@
 # image-stitcher
 
-## Setup
+## Run the GUI
+
+On linux (e.g. ubuntu), ensure you have the necessary system dependencies
+installed. We provide a setup script for ubuntu 22.04 LTS that does this
+automatically:
+
+```
+./setup_ubuntu_22_04.sh
+```
+for other distributions / versions, the exact packages may be slightly
+different.
+
+On mac OS, make sure you have `curl` installed (e.g. `brew install curl`) if
+you don't already.
+
+Then either double click the `run_gui` script or from this repository's directory run:
+```
+./run_gui
+```
+(this will install [`uv`](https://docs.astral.sh/uv/) if you don't already have
+it to automatically fetch and install python dependencies for your platform)
+
+## CLI / developer setup
 
 This repository uses [uv](https://docs.astral.sh/uv/) to manage its environment and dependencies.
 If you don't already have it, install from
-https://docs.astral.sh/uv/getting-started/installation/.
-
-## Devtools
-
-This repository is set up with [ruff](https://docs.astral.sh/ruff/) for linting
-and formatting, and [mypy](https://mypy.readthedocs.io) for type checking. The
-shell scripts in the dev directory can be used to invoke these tools and should
-be run from the repository root.
+https://docs.astral.sh/uv/getting-started/installation/ or run the `dev/ensure_uv.sh` script.
 
 ## Running via the CLI
 
@@ -22,7 +37,14 @@ uv run python -m image_stitcher.stitcher_cli --help
 ```
 to see the options and their documentation.
 
-## Running the GUI
+## Devtools
+
+This repository is set up with [ruff](https://docs.astral.sh/ruff/) for linting
+and formatting, and [mypy](https://mypy.readthedocs.io) for type checking. The
+shell scripts in the dev directory can be used to invoke these tools and should
+be run from the repository root.
+
+## Running the GUI manually
 
 ```
 uv run --extra gui python -m image_stitcher.stitcher_gui

--- a/dev/ensure_uv.sh
+++ b/dev/ensure_uv.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+if ! command -v uv 2>&1 >/dev/null
+then
+    echo "Installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+else
+    echo "uv is already installed"
+fi

--- a/run_gui
+++ b/run_gui
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+cd -- "$(dirname "$(realpath -- "${BASH_SOURCE[0]}")")"
+
+./dev/ensure_uv.sh
+/bin/bash -c 'uv run --extra gui python -m image_stitcher.stitcher_gui'

--- a/setup_ubuntu_22_04.sh
+++ b/setup_ubuntu_22_04.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+sudo apt-get update && sudo apt-get install -y \
+    curl libxml2 libxslt1.1 fontconfig libgl1 \
+    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 \
+    libxcb-shape0 libxcb-xinerama0 libxcb-xkb1 libxkbcommon0 \
+    libxkbcommon-x11-0
+cd -- "$(dirname "$(realpath -- "${BASH_SOURCE[0]}")")"
+./dev/ensure_uv.sh


### PR DESCRIPTION
For ease of use, we'd prefer not to have people run a bunch of terminal commands manually. In contrast to the main microscope software, we'd also like to keep this tool isolated in a virtualenv to reduce the chance that analysis tools can break the microscope software.

This commit adds some setup scripts that can help do this:
- `setup_ubuntu_22_04.sh` there's a bunch of extra system dependencies we need on ubuntu (mostly for QT); this installs them automatically. I chose ubuntu 22 since it's the same OS the microscope software installation script targets.
- `dev/ensure_uv.sh` a wrapper around the installer for uv, which we use to manage the virtualenvs, python installation, and python dependencies
- `run_gui` ensures that uv is installed by calling into `dev/ensure_uv.sh` and then runs the GUI command. This is also double-clickable on mac (and presumably linux, though I don't have a non-containerized ubuntu 22.04 installation to test on)

Tested by:
- create a fresh ubuntu 22.04 container
- `./setup_ubuntu_22_04.sh`
- `./run_gui`
- see these succeed, I get the stitching gui, and can stitch some images
- double click `run_gui` on mac, see I get the stitching gui and can stitch some images