### PR TITLE
Add an option to turn on/off compression for the output

### DIFF
--- a/image_stitcher/parameters.py
+++ b/image_stitcher/parameters.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Annotated, Any, ClassVar, NamedTuple, assert_never
+from typing import Annotated, Any, ClassVar, Literal, NamedTuple, assert_never
 
 import numpy as np
 import pandas as pd
@@ -75,6 +75,14 @@ class StitchingParameters(
 
     Ignored if not writing to ome-zarr as the output format. The default, `None`
     means we infer the number of output levels based on the size of the input images.
+    """
+
+    output_compression: Literal["default", "none"] = "default"
+    """Override the compression for the output zarr array.
+
+    (Ignored unless the output type is ome-zarr.) Currently the only options are
+    "none" for uncompressed output and "default" to use the zarr library's
+    default compression algorithm.
     """
 
     def model_post_init(self, __context: Any) -> None:

--- a/image_stitcher/stitcher.py
+++ b/image_stitcher/stitcher.py
@@ -372,7 +372,7 @@ class Stitcher:
         # Configure storage options with optimal chunking
         storage_opts = {
             "chunks": self.computed_parameters.chunks,
-            "compressor": zarr.storage.default_compressor,
+            "compressor": self.params.output_compression,
         }
 
         if isinstance(stitched_region, zarr.Array):


### PR DESCRIPTION
This commit adds a parameter to the CLI to control the compression of the output (currently the only options are "default" for the zarr library's default compression algorithm and "none" for uncompressed).

Tested by:
- `uv run python -m image_stitcher.stitcher_cli --verbose --output-format .ome.zarr --input-folder ~/cephla-images/16x16_2025-01-17_09-25-24.710194 --output-compression default`
- `uv run python -m image_stitcher.stitcher_cli --verbose --output-format .ome.zarr --input-folder ~/cephla-images/16x16_2025-01-17_09-25-24.710194 --output-compression none`
- see the second output is about twice as large on disk as the first.