### PR TITLE
fix: make sure to re-chunk pyramid levels and dask array top level

### DIFF
--- a/image_stitcher/stitcher_test.py
+++ b/image_stitcher/stitcher_test.py
@@ -17,7 +17,7 @@ class StitcherTest(unittest.TestCase):
             im_size=ImagePlaneDims(1000, 1000),
             channel_names=["DAPI", "FITC", "TRITC"],
             step_mm=(1.0, 1.0),
-            sensor_pixel_size_µm=20.0,
+            sensor_pixel_size_um=20.0,
             magnification=20.0,
         ) as params:
             output_filename = None
@@ -51,7 +51,7 @@ class StitcherTest(unittest.TestCase):
             im_size=ImagePlaneDims(1000, 1000),
             channel_names=["DAPI", "FITC", "TRITC"],
             step_mm=(1.0, 1.0),
-            sensor_pixel_size_µm=20.0,
+            sensor_pixel_size_um=20.0,
             magnification=20.0,
             disk_based_output_arr=True,
         ) as params:
@@ -86,7 +86,7 @@ class StitcherTest(unittest.TestCase):
                 im_size=ImagePlaneDims(1000, 1000),
                 channel_names=["DAPI", "FITC", "TRITC"],
                 step_mm=(1.0, 1.0),
-                sensor_pixel_size_µm=20.0,
+                sensor_pixel_size_um=20.0,
                 magnification=20.0,
                 pyramid_levels=6
         ) as params:
@@ -104,12 +104,14 @@ class StitcherTest(unittest.TestCase):
             self.assertIsNotNone(output_filename)
 
             im = next(Reader(parse_url(output_filename))()).data[0]
-            self.assertEqual(im.shape, (1, 3, 1, 3000, 3000))
+            self.assertEqual(im.shape, (1, 3, 1, 5000, 5000))
+            # The generated images have values corresponding to the field of view of each capture,
+            # so we can check for valid ordering (up to the fov level) by checking that below.
             self.assertEqual(im[0, 0, 0, 0, 0].compute(), 0)
-            self.assertEqual(im[0, 0, 0, 1000, 0].compute(), 3)
-            self.assertEqual(im[0, 0, 0, 1500, 0].compute(), 3)
-            self.assertEqual(im[0, 0, 0, 2000, 0].compute(), 6)
+            self.assertEqual(im[0, 0, 0, 1000, 0].compute(), 5)
+            self.assertEqual(im[0, 0, 0, 1500, 0].compute(), 5)
+            self.assertEqual(im[0, 0, 0, 2000, 0].compute(), 10)
             self.assertEqual(im[0, 0, 0, 0, 1000].compute(), 1)
             self.assertEqual(im[0, 0, 0, 0, 1500].compute(), 1)
             self.assertEqual(im[0, 0, 0, 0, 2000].compute(), 2)
-            self.assertEqual(im[0, 0, 0, 2999, 2999].compute(), 8)
+            self.assertEqual(im[0, 0, 0, 2999, 2999].compute(), 12)

--- a/image_stitcher/stitcher_test.py
+++ b/image_stitcher/stitcher_test.py
@@ -77,3 +77,39 @@ class StitcherTest(unittest.TestCase):
             self.assertEqual(im[0, 0, 0, 0, 1500].compute(), 1)
             self.assertEqual(im[0, 0, 0, 0, 2000].compute(), 2)
             self.assertEqual(im[0, 0, 0, 2999, 2999].compute(), 8)
+
+    def test_stitch_with_pyramid_and_zarr_out(self) -> None:
+        with temporary_image_directory_params(
+                n_rows=5,
+                n_cols=5,
+                # Exactly non-overlapping images aligned in a grid.
+                im_size=ImagePlaneDims(1000, 1000),
+                channel_names=["DAPI", "FITC", "TRITC"],
+                step_mm=(1.0, 1.0),
+                sensor_pixel_size_µm=20.0,
+                magnification=20.0,
+                pyramid_levels=6
+        ) as params:
+            output_filename = None
+
+            def finished_saving(output_path: str, _dtype: object) -> None:
+                nonlocal output_filename
+                output_filename = output_path
+
+            callbacks = ProgressCallbacks.no_op()
+            callbacks.finished_saving = finished_saving
+
+            stitcher = Stitcher(params.parent, callbacks)
+            stitcher.run()
+            self.assertIsNotNone(output_filename)
+
+            im = next(Reader(parse_url(output_filename))()).data[0]
+            self.assertEqual(im.shape, (1, 3, 1, 3000, 3000))
+            self.assertEqual(im[0, 0, 0, 0, 0].compute(), 0)
+            self.assertEqual(im[0, 0, 0, 1000, 0].compute(), 3)
+            self.assertEqual(im[0, 0, 0, 1500, 0].compute(), 3)
+            self.assertEqual(im[0, 0, 0, 2000, 0].compute(), 6)
+            self.assertEqual(im[0, 0, 0, 0, 1000].compute(), 1)
+            self.assertEqual(im[0, 0, 0, 0, 1500].compute(), 1)
+            self.assertEqual(im[0, 0, 0, 0, 2000].compute(), 2)
+            self.assertEqual(im[0, 0, 0, 2999, 2999].compute(), 8)

--- a/image_stitcher/testutil.py
+++ b/image_stitcher/testutil.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 import tempfile
 from datetime import datetime, timezone
-from typing import Generator
+from typing import Generator, Optional
 
 import numpy as np
 import pandas as pd
@@ -36,6 +36,7 @@ def temporary_image_directory_params(
     sensor_pixel_size_µm: float = 7.52,
     magnification: float = 20.0,
     disk_based_output_arr: bool = False,
+    pyramid_levels: Optional[int] = None
 ) -> Generator[StitchingComputedParameters, None, None]:
     """Set up the files that the computed parameters requires for setup.
 
@@ -112,6 +113,8 @@ def temporary_image_directory_params(
             json.dump(acq_params, f)
 
         base_params = StitchingParameters.from_json_file(str(PARAMETERS_FIXTURE_FILE))
+        if pyramid_levels:
+            base_params.num_pyramid_levels = pyramid_levels
         if disk_based_output_arr:
             base_params.force_stitch_to_disk = True
         base_params.input_folder = str(base_dir)

--- a/image_stitcher/testutil.py
+++ b/image_stitcher/testutil.py
@@ -33,7 +33,7 @@ def temporary_image_directory_params(
     channel_names: list[str],
     name: str = "image_inputs",
     step_mm: tuple[float, float] = (3.2, 3.2),
-    sensor_pixel_size_µm: float = 7.52,
+    sensor_pixel_size_um: float = 7.52,
     magnification: float = 20.0,
     disk_based_output_arr: bool = False,
     pyramid_levels: Optional[int] = None
@@ -82,7 +82,7 @@ def temporary_image_directory_params(
                 )
                 for ch in channel_names:
                     im_file = base_dir / "0" / image_filename(fov_counter, ch)
-                    skimage.io.imsave(im_file, make_fake_image(fov_counter))
+                    skimage.io.imsave(im_file, make_fake_image(fov_counter), check_contrast=False)
                 fov_counter += 1
 
         coords = pd.DataFrame(coordinates)
@@ -105,7 +105,7 @@ def temporary_image_directory_params(
                 "tube_lens_f_mm": 180.0,
                 "name": "20x",
             },
-            "sensor_pixel_size_um": sensor_pixel_size_μm,
+            "sensor_pixel_size_um": sensor_pixel_size_um,
             "tube_lens_mm": 180,
         }
 


### PR DESCRIPTION
For zarr output, we need "regular chunks".  Where that is defined as "all chunks in a dimension are the same size, except for the last that can be smaller".  

We were rechunking in 1 case before, but weren't rechunking for dask array case and weren't rechunking for any of the pyramid levels.  This adds rechunking to our pre-computed chunk size for all of these.

There is still 1 question mark about the zarr case that isn't handled, but I didn't have a dataset to test that with.

Tested by: A new unit test that does pyramid creation.  It fails before this PR's content, and passes after.