### PR TITLE
flatfield: instead of loading all images, only load those used for flatfield

### DIFF
--- a/image_stitcher/stitcher_test.py
+++ b/image_stitcher/stitcher_test.py
@@ -19,6 +19,42 @@ class StitcherTest(unittest.TestCase):
             step_mm=(1.0, 1.0),
             sensor_pixel_size_um=20.0,
             magnification=20.0,
+            flatfield_correction=False
+        ) as params:
+            output_filename = None
+
+            def finished_saving(output_path: str, _dtype: object) -> None:
+                nonlocal output_filename
+                output_filename = output_path
+
+            callbacks = ProgressCallbacks.no_op()
+            callbacks.finished_saving = finished_saving
+            stitcher = Stitcher(params.parent, callbacks)
+            stitcher.run()
+            self.assertIsNotNone(output_filename)
+
+            im = next(Reader(parse_url(output_filename))()).data[0]
+            self.assertEqual(im.shape, (1, 3, 1, 3000, 3000))
+            self.assertEqual(im[0, 0, 0, 0, 0].compute(), 0)
+            self.assertEqual(im[0, 0, 0, 1000, 0].compute(), 3)
+            self.assertEqual(im[0, 0, 0, 1500, 0].compute(), 3)
+            self.assertEqual(im[0, 0, 0, 2000, 0].compute(), 6)
+            self.assertEqual(im[0, 0, 0, 0, 1000].compute(), 1)
+            self.assertEqual(im[0, 0, 0, 0, 1500].compute(), 1)
+            self.assertEqual(im[0, 0, 0, 0, 2000].compute(), 2)
+            self.assertEqual(im[0, 0, 0, 2999, 2999].compute(), 8)
+
+    def test_basic_stage_stitching_with_flatfield(self) -> None:
+        with temporary_image_directory_params(
+            n_rows=3,
+            n_cols=3,
+            # Exactly non-overlapping images aligned in a grid.
+            im_size=ImagePlaneDims(1000, 1000),
+            channel_names=["DAPI", "FITC", "TRITC"],
+            step_mm=(1.0, 1.0),
+            sensor_pixel_size_um=20.0,
+            magnification=20.0,
+            flatfield_correction=True
         ) as params:
             output_filename = None
 

--- a/image_stitcher/testutil.py
+++ b/image_stitcher/testutil.py
@@ -36,7 +36,8 @@ def temporary_image_directory_params(
     sensor_pixel_size_um: float = 7.52,
     magnification: float = 20.0,
     disk_based_output_arr: bool = False,
-    pyramid_levels: Optional[int] = None
+    pyramid_levels: Optional[int] = None,
+    flatfield_correction: bool = False
 ) -> Generator[StitchingComputedParameters, None, None]:
     """Set up the files that the computed parameters requires for setup.
 
@@ -117,6 +118,8 @@ def temporary_image_directory_params(
             base_params.num_pyramid_levels = pyramid_levels
         if disk_based_output_arr:
             base_params.force_stitch_to_disk = True
+        if flatfield_correction:
+            base_params.apply_flatfield = flatfield_correction
         base_params.input_folder = str(base_dir)
         computed = StitchingComputedParameters(base_params)
         yield computed


### PR DESCRIPTION
We had one reported case of flatfield correction causing memory exhaustion.  We already had this flatfield correction limit in place, but it still loaded all the images for every time point.  Now we just load the metadata, and only choose up to the max image count to load from disk.

Tested by: I added a stitch test with flatfield enabled, and checked that it runs and appears to give correct results.  I don't have a big enough dataset to test the memory exhaustion issue, though.  So I need help with that.