### PR TITLE
setup and run_gui: fix conda init and activation

### DIFF
--- a/run_gui
+++ b/run_gui
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -6,4 +6,13 @@ readonly script_dir="$(dirname "$(realpath -- "${BASH_SOURCE[0]}")")"
 
 cd -- "${script_dir}"
 
+# Setup conda, then activate the image-stitcher environment.  The image-sticher
+# environment should already exist from running the setup script.
+echo "Setting up conda..."
+eval "$(conda shell.bash hook)"
+
+echo "Activating the image-stitcher conda environment..."
+conda activate image-stitcher
+
+echo "Running the image stitcher gui..."
 python -m image_stitcher.stitcher_gui

--- a/setup_ubuntu_22_04.sh
+++ b/setup_ubuntu_22_04.sh
@@ -20,7 +20,7 @@ then
     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O "${minoconda_installer}"
     bash "${minoconda_installer}" -b -u -p "${miniconda_install_dir}"
 
-    conda init --all
+    $miniconda_install_dir/bin/conda init --all
     readonly miniconda_base_dir="$miniconda_install_dir"
     echo "Using base environment location: '${miniconda_base_dir}'"
 else


### PR DESCRIPTION
See title.

Tested by:
  1. Blasting all conda init from my `.bashrc` and `.zshrc` including any `PATH`.  `ag conda` returns nothing on both.
  2. Open a new shell to make sure my `env` is clean
  3. run the setup script
  4. Follow the instructions the setup script prints to run the gui
  5. Open a new shell
  6. Run the gui

Both 4 and 6 result in successfully running the gui.  The setup script instructions are still needed if the user wants to run in the same terminal since we can't affect the caller's env.