### PR TITLE
option to load flatfield .npy files

### DIFF
--- a/image_stitcher/flatfield_correction.py
+++ b/image_stitcher/flatfield_correction.py
@@ -48,22 +48,25 @@ def compute_flatfield_correction(
             # We might have a ton of images for this time point.  We only want to select up to MAX_FLATFIELD_IMAGES
             # to use for flatfield correction.  To do this, load all the metadata and pick random tile infos
             # to use for this timepoint.
-            all_tile_infos.extend([
-                tile
-                for key, tile in computed_params.acquisition_metadata.items()
-                if tile.channel == channel and key.t == int(t)
-            ])
+            all_tile_infos.extend(
+                [
+                    tile
+                    for key, tile in computed_params.acquisition_metadata.items()
+                    if tile.channel == channel and key.t == int(t)
+                ]
+            )
 
         random.shuffle(all_tile_infos)
-        selected_tile_infos = all_tile_infos[: min(MAX_FLATFIELD_IMAGES, len(all_tile_infos))]
+        selected_tile_infos = all_tile_infos[
+            : min(MAX_FLATFIELD_IMAGES, len(all_tile_infos))
+        ]
 
         if len(selected_tile_infos) < len(all_tile_infos):
-            logging.warning(f"Limiting flatfield correction to {len(selected_tile_infos)} images instead of using all {len(all_tile_infos)}")
+            logging.warning(
+                f"Limiting flatfield correction to {len(selected_tile_infos)} images instead of using all {len(all_tile_infos)}"
+            )
 
-        images = [
-            imread(tile.filepath)
-            for tile in selected_tile_infos
-        ]
+        images = [imread(tile.filepath) for tile in selected_tile_infos]
 
         if not images:
             logging.warning(f"No images found for channel {channel} for any timepoint")

--- a/image_stitcher/flatfield_utils.py
+++ b/image_stitcher/flatfield_utils.py
@@ -1,0 +1,75 @@
+# image_stitcher/flatfield_utils.py
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+import numpy as np
+from .parameters import StitchingComputedParameters
+
+
+def _find_manifest(directory: Path) -> Optional[Path]:
+    """
+    Search for the first .json or .npy file in the directory and return its Path.
+    Returns None if no such file is found.
+    """
+    for pat in ("*.json", "*.npy"):
+        hits = list(directory.glob(pat))
+        if hits:
+            return hits[0]
+    return None
+
+
+def load_flatfield_correction(
+    directory: Path, computed_params: StitchingComputedParameters
+) -> dict[int, np.ndarray]:
+    """
+    Look for flatfield_manifest.{json,npy} in directory,
+    load each channel’s .npy, and return channel‐idx → flatfield array.
+    """
+    manifest_path = _find_manifest(directory)
+    if manifest_path is None:
+        logging.warning(f"No flatfield manifest found in {directory!r}")
+        return {}
+
+    data = json.loads(manifest_path.read_text())
+    flatfields: dict[int, np.ndarray] = {}
+
+    for ch_key, fname in data["files"].items():
+        p = directory / fname
+        if not p.exists():
+            logging.warning(f"Flatfield file {p!r} missing; skipping channel {ch_key}")
+            continue
+
+        arr = np.load(p)
+
+        # Try to interpret manifest key as an integer (wavelength or index)
+        try:
+            idx = int(ch_key)
+            # If the int is a wavelength, map to channel index by substring match
+            matches = [
+                i
+                for i, name in enumerate(computed_params.monochrome_channels)
+                if str(idx) in name
+            ]
+            if matches:
+                idx = matches[0]
+            # If not found, assume it's already an index
+            elif idx < len(computed_params.monochrome_channels):
+                pass
+            else:
+                logging.warning(
+                    f"No channel found for manifest key '{ch_key}'; skipping"
+                )
+                continue
+        except ValueError:
+            # Otherwise treat it as a channel-name and look up its index
+            try:
+                idx = computed_params.monochrome_channels.index(ch_key)
+            except ValueError:
+                logging.warning(f"Unknown channel '{ch_key}' in manifest; skipping")
+                continue
+
+        flatfields[idx] = arr
+
+    logging.info(f"Loaded flatfields for channel-indices: {list(flatfields.keys())}")
+    return flatfields

--- a/image_stitcher/flatfield_utils.py
+++ b/image_stitcher/flatfield_utils.py
@@ -7,45 +7,62 @@ import numpy as np
 from .parameters import StitchingComputedParameters
 
 
-def _find_manifest(directory: Path) -> Optional[Path]:
-    """
-    Search for the first .json or .npy file in the directory and return its Path.
-    Returns None if no such file is found.
-    """
-    for pat in ("*.json", "*.npy"):
-        hits = list(directory.glob(pat))
-        if hits:
-            return hits[0]
-    return None
-
-
 def load_flatfield_correction(
-    directory: Path, computed_params: StitchingComputedParameters
+    manifest_filepath: Path, computed_params: StitchingComputedParameters
 ) -> dict[int, np.ndarray]:
     """
-    Look for flatfield_manifest.{json,npy} in directory,
-    load each channel’s .npy, and return channel‐idx → flatfield array.
+    Load flatfield correction data from a specified manifest file.
+
+    The manifest file (JSON) should contain a "files" dictionary,
+    mapping channel keys to .npy filenames. These .npy files are expected
+    to be in the same directory as the manifest file.
+
+    Args:
+        manifest_filepath: Path to the flatfield manifest JSON file.
+        computed_params: Computed stitching parameters.
+
+    Returns:
+        A dictionary mapping channel-index to the flatfield numpy array.
+        Returns an empty dictionary if the manifest is not found, is invalid,
+        or if referenced .npy files are missing.
     """
-    manifest_path = _find_manifest(directory)
-    if manifest_path is None:
-        logging.warning(f"No flatfield manifest found in {directory!r}")
+    if not manifest_filepath.is_file():
+        logging.warning(f"Flatfield manifest file not found or is not a file: {manifest_filepath!r}")
         return {}
 
-    data = json.loads(manifest_path.read_text())
+    try:
+        data = json.loads(manifest_filepath.read_text())
+    except json.JSONDecodeError as e:
+        logging.warning(f"Error decoding JSON from manifest file {manifest_filepath!r}: {e}")
+        return {}
+
     flatfields: dict[int, np.ndarray] = {}
 
+    if "files" not in data or not isinstance(data["files"], dict):
+        logging.warning(f"Manifest file {manifest_filepath!r} is missing 'files' dictionary or it is malformed.")
+        return {}
+
+    manifest_dir = manifest_filepath.parent
     for ch_key, fname in data["files"].items():
-        p = directory / fname
-        if not p.exists():
-            logging.warning(f"Flatfield file {p!r} missing; skipping channel {ch_key}")
+        # Ensure fname is a string, as it comes from JSON
+        if not isinstance(fname, str):
+            logging.warning(f"Invalid filename type for channel key '{ch_key}' in manifest {manifest_filepath!r}. Expected string, got {type(fname)}. Skipping.")
             continue
 
-        arr = np.load(p)
+        p = manifest_dir / fname
+        if not p.exists(): # Check .is_file() if you want to be more strict
+            logging.warning(f"Flatfield file {p!r} (referenced by manifest {manifest_filepath!r} for channel '{ch_key}') missing; skipping channel.")
+            continue
+
+        try:
+            arr = np.load(p)
+        except Exception as e: # Catch potential errors during np.load
+            logging.warning(f"Error loading flatfield array from {p!r} for channel '{ch_key}': {e}. Skipping.")
+            continue
 
         # Try to interpret manifest key as an integer (wavelength or index)
         try:
             idx = int(ch_key)
-            # If the int is a wavelength, map to channel index by substring match
             matches = [
                 i
                 for i, name in enumerate(computed_params.monochrome_channels)
@@ -53,12 +70,9 @@ def load_flatfield_correction(
             ]
             if matches:
                 idx = matches[0]
-            # If not found, assume it's already an index
-            elif idx < len(computed_params.monochrome_channels):
-                pass
-            else:
+            elif idx < 0 or idx >= len(computed_params.monochrome_channels): # Check bounds if it's an index
                 logging.warning(
-                    f"No channel found for manifest key '{ch_key}'; skipping"
+                    f"Channel index '{ch_key}' out of bounds for monochrome_channels (len {len(computed_params.monochrome_channels)}); skipping"
                 )
                 continue
         except ValueError:
@@ -66,10 +80,13 @@ def load_flatfield_correction(
             try:
                 idx = computed_params.monochrome_channels.index(ch_key)
             except ValueError:
-                logging.warning(f"Unknown channel '{ch_key}' in manifest; skipping")
+                logging.warning(f"Unknown channel name '{ch_key}' in manifest {manifest_filepath!r}; skipping")
                 continue
 
         flatfields[idx] = arr
 
-    logging.info(f"Loaded flatfields for channel-indices: {list(flatfields.keys())}")
+    if flatfields:
+        logging.info(f"Loaded flatfields from {manifest_filepath!r} for channel-indices: {list(flatfields.keys())}")
+    else:
+        logging.warning(f"No flatfields were successfully loaded from manifest {manifest_filepath!r}.")
     return flatfields

--- a/image_stitcher/parameters.py
+++ b/image_stitcher/parameters.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Annotated, Any, ClassVar, Literal, NamedTuple
+from typing import Annotated, Any, ClassVar, Literal, NamedTuple, Optional
 
 import numpy as np
 import pandas as pd
@@ -60,6 +60,9 @@ class StitchingParameters(
 
     apply_flatfield: bool = False
     """Whether to apply a flatfield correction to the images prior to stitching."""
+
+    flatfield_manifest: Optional[pathlib.Path] = None
+    """If set, a path (folder or .json) from which to load precomputed flatfields."""
 
     verbose: bool = False
     """Show debug-level logging."""

--- a/image_stitcher/stitcher_gui.py
+++ b/image_stitcher/stitcher_gui.py
@@ -2,6 +2,7 @@ import logging
 import sys
 from typing import Any, cast
 import pathlib
+import enum
 
 import napari
 import numpy as np
@@ -25,6 +26,24 @@ from PyQt5.QtWidgets import (
 
 from .parameters import OutputFormat, ScanPattern, StitchingParameters
 from .stitcher import ProgressCallbacks, Stitcher
+
+# Enum for Flatfield Modes
+class FlatfieldModeOption(enum.Enum):
+    NONE = "No Flatfield Correction"
+    COMPUTE = "Compute Flatfield Correction"
+    LOAD = "Load Precomputed Flatfield"
+
+def get_flatfield_mode_from_string(combo_value: str) -> FlatfieldModeOption:
+    if combo_value == FlatfieldModeOption.NONE.value:
+        return FlatfieldModeOption.NONE
+    elif combo_value == FlatfieldModeOption.COMPUTE.value:
+        return FlatfieldModeOption.COMPUTE
+    elif combo_value == FlatfieldModeOption.LOAD.value:
+        return FlatfieldModeOption.LOAD
+    else:
+        # This case should ideally not be reached if combo box items are populated from the enum.
+        raise ValueError(f"Unknown flatfield mode string from combo box: '{combo_value}'")
+
 
 # TODO(colin): this is almost but not quite the same as the map in
 # StitchingComputedParameters.get_channel_color. Reconcile the differences?
@@ -98,16 +117,12 @@ class StitchingGUI(QWidget):
         # --- Flatfield Correction Options ---
         self.flatfieldModeCombo = QComboBox(self)
         self.flatfieldModeCombo.addItems(
-            [
-                "No Flatfield Correction",
-                "Compute Flatfield Correction",
-                "Load Precomputed Flatfield",
-            ]
+            [mode.value for mode in FlatfieldModeOption]
         )
         self.flatfieldModeCombo.currentIndexChanged.connect(self.onFlatfieldModeChanged)
         self.layout.addWidget(self.flatfieldModeCombo)
 
-        self.loadFlatfieldBtn = QPushButton("Select Flatfield Folder", self)
+        self.loadFlatfieldBtn = QPushButton("Select Flatfield Manifest File", self)
         self.loadFlatfieldBtn.clicked.connect(self.onLoadFlatfield)
         self.loadFlatfieldBtn.setVisible(False)
         self.layout.addWidget(self.loadFlatfieldBtn)  # type: ignore
@@ -170,17 +185,21 @@ class StitchingGUI(QWidget):
             )
             return
 
-        # # In StitchingGUI.onStitchingStart():
-        # if self.outputFormatCombo.currentText() == 'OME-TIFF' and (self.mergeTimepointsCheck.isChecked() or self.mergeRegionsCheck.isChecked()):
-        #     QMessageBox.warning(self, "Format Warning",
-        #                        "Merging operations are only supported for OME-ZARR format. "
-        #                        "These operations will be skipped.")
-
         try:
             # Create parameters from UI state
-            mode = self.flatfieldModeCombo.currentIndex()
-            apply_flatfield = mode in (1, 2)
-            flatfield_manifest = self.flatfield_manifest if mode == 2 else None
+            selected_flatfield_str = self.flatfieldModeCombo.currentText()
+            flatfield_mode_option = get_flatfield_mode_from_string(selected_flatfield_str)
+
+            apply_flatfield = flatfield_mode_option in (
+                FlatfieldModeOption.COMPUTE,
+                FlatfieldModeOption.LOAD,
+            )
+            flatfield_manifest_to_use = (
+                self.flatfield_manifest
+                if flatfield_mode_option == FlatfieldModeOption.LOAD
+                else None
+            )
+
             params = StitchingParameters(
                 input_folder=self.inputDirectory,
                 output_format=OutputFormat(
@@ -188,7 +207,7 @@ class StitchingGUI(QWidget):
                 ),
                 scan_pattern=ScanPattern.unidirectional,
                 apply_flatfield=apply_flatfield,
-                flatfield_manifest=flatfield_manifest,
+                flatfield_manifest=flatfield_manifest_to_use,
             )
 
             if self.outputFormatCombo.currentText() == "OME-ZARR":
@@ -245,22 +264,29 @@ class StitchingGUI(QWidget):
             self.pyramidLevels.show()
 
     def onFlatfieldModeChanged(self, idx: int) -> None:
-        self.loadFlatfieldBtn.setVisible(idx == 2)
-        if idx != 2:
+        selected_mode_str = self.flatfieldModeCombo.currentText()
+        flatfield_mode_option = get_flatfield_mode_from_string(selected_mode_str)
+
+        self.loadFlatfieldBtn.setVisible(flatfield_mode_option == FlatfieldModeOption.LOAD)
+        
+        if flatfield_mode_option != FlatfieldModeOption.LOAD:
             self.flatfield_manifest = None
-            self.loadFlatfieldBtn.setText("Select Flatfield Folder")
-        elif idx == 2 and self.flatfield_manifest:
-            self.loadFlatfieldBtn.setText(f"Loaded: {self.flatfield_manifest.name}")
+            self.loadFlatfieldBtn.setText("Select Flatfield Manifest File")
+        elif self.flatfield_manifest:
+            self.loadFlatfieldBtn.setText(f"Selected: {self.flatfield_manifest.name}")
         else:
-            self.loadFlatfieldBtn.setText("Select Flatfield Folder")
+            self.loadFlatfieldBtn.setText("Select Flatfield Manifest File")
 
     def onLoadFlatfield(self) -> None:
-        directory = QFileDialog.getExistingDirectory(self, "Select Flatfield Folder")
-        if directory:
-            self.flatfield_manifest = pathlib.Path(directory)
-            self.loadFlatfieldBtn.setText(f"Loaded: {self.flatfield_manifest.name}")
+        manifest_filepath_str, _ = QFileDialog.getOpenFileName(
+            self, "Select Flatfield Manifest File", "", "JSON files (*.json)"
+        )
+        if manifest_filepath_str:
+            self.flatfield_manifest = pathlib.Path(manifest_filepath_str)
+            self.loadFlatfieldBtn.setText(f"Selected: {self.flatfield_manifest.name}")
         else:
-            self.loadFlatfieldBtn.setText("Select Flatfield Folder")
+            if not self.flatfield_manifest:
+                self.loadFlatfieldBtn.setText("Select Flatfield Manifest File")
 
     def setupConnections(self) -> None:
         assert self.stitcher is not None
@@ -342,12 +368,11 @@ class StitchingGUI(QWidget):
             logging.error(f"An error occurred while opening output in Napari: {e}")
 
     def extractWavelength(self, name: str) -> str | None:
-        # Split the string and find the wavelength number immediately after "Fluorescence"
         parts = name.split()
         if "Fluorescence" in parts:
             index = parts.index("Fluorescence") + 1
             if index < len(parts):
-                return parts[index].split()[0]  # Assuming '488 nm Ex' and taking '488'
+                return parts[index].split()[0]
         for color in ["R", "G", "B"]:
             if color in parts or "full_" + color in parts:
                 return color

--- a/image_stitcher/stitcher_test.py
+++ b/image_stitcher/stitcher_test.py
@@ -1,4 +1,8 @@
 import unittest
+import tempfile
+import pathlib
+import json
+import numpy as np
 
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Reader
@@ -151,3 +155,67 @@ class StitcherTest(unittest.TestCase):
             self.assertEqual(im[0, 0, 0, 0, 1500].compute(), 1)
             self.assertEqual(im[0, 0, 0, 0, 2000].compute(), 2)
             self.assertEqual(im[0, 0, 0, 2999, 2999].compute(), 12)
+
+    def test_stitching_with_flatfield_manifest(self) -> None:
+        im_size = ImagePlaneDims(1000, 1000)
+        # Using 3 channels to match pixel assertions from test_basic_stage_stitching
+        channel_names = ["DAPI", "FITC", "TRITC"]
+
+        with tempfile.TemporaryDirectory() as temp_manifest_dir_str:
+            temp_manifest_dir = pathlib.Path(temp_manifest_dir_str)
+
+            # Create dummy .npy flatfield files (arrays of ones for no-op)
+            flatfield_files_data = {}
+            for ch_name in channel_names:
+                npy_filename = f"{ch_name}_flatfield.npy"
+                # Flatfield array should be float for division, ones for no-op
+                flatfield_array = np.ones((im_size.height_px, im_size.width_px), dtype=np.float32)
+                np.save(temp_manifest_dir / npy_filename, flatfield_array)
+                flatfield_files_data[ch_name] = npy_filename
+
+            # Create dummy flatfield_manifest.json
+            manifest_content = {"files": flatfield_files_data}
+            manifest_path = temp_manifest_dir / "flatfield_manifest.json"
+            with open(manifest_path, "w") as f_manifest:
+                json.dump(manifest_content, f_manifest)
+
+            with temporary_image_directory_params(
+                n_rows=3,
+                n_cols=3,
+                im_size=im_size,
+                channel_names=channel_names,
+                step_mm=(1.0, 1.0),
+                sensor_pixel_size_um=20.0,
+                magnification=20.0,
+                # flatfield_correction is False by default in temporary_image_directory_params
+                # We will set apply_flatfield and flatfield_manifest on the params directly
+            ) as computed_params:
+                # Configure StitchingParameters (parent of computed_params) to use the manifest
+                computed_params.parent.apply_flatfield = True
+                computed_params.parent.flatfield_manifest = manifest_path
+
+                output_filename = None
+
+                def finished_saving(output_path_str: str, _dtype: object) -> None:
+                    nonlocal output_filename
+                    output_filename = output_path_str
+
+                callbacks = ProgressCallbacks.no_op()
+                callbacks.finished_saving = finished_saving
+                # Stitcher expects StitchingParameters (computed_params.parent)
+                stitcher = Stitcher(computed_params.parent, callbacks)
+                stitcher.run()
+                self.assertIsNotNone(output_filename)
+
+                im = next(Reader(parse_url(output_filename))()).data[0]
+                # Assertions match test_basic_stage_stitching due to no-op flatfield
+                self.assertEqual(im.shape, (1, len(channel_names), 1, 3000, 3000))
+                # Pixel values are (fov % 65536)
+                self.assertEqual(im[0, 0, 0, 0, 0].compute(), 0)    # FOV 0
+                self.assertEqual(im[0, 0, 0, 1000, 0].compute(), 3) # FOV 3
+                self.assertEqual(im[0, 0, 0, 1500, 0].compute(), 3) # FOV 3
+                self.assertEqual(im[0, 0, 0, 2000, 0].compute(), 6) # FOV 6
+                self.assertEqual(im[0, 0, 0, 0, 1000].compute(), 1) # FOV 1
+                self.assertEqual(im[0, 0, 0, 0, 1500].compute(), 1) # FOV 1
+                self.assertEqual(im[0, 0, 0, 0, 2000].compute(), 2) # FOV 2
+                self.assertEqual(im[0, 0, 0, 2999, 2999].compute(), 8) # FOV 8

--- a/image_stitcher/stitcher_test.py
+++ b/image_stitcher/stitcher_test.py
@@ -19,7 +19,7 @@ class StitcherTest(unittest.TestCase):
             step_mm=(1.0, 1.0),
             sensor_pixel_size_um=20.0,
             magnification=20.0,
-            flatfield_correction=False
+            flatfield_correction=False,
         ) as params:
             output_filename = None
 
@@ -54,7 +54,7 @@ class StitcherTest(unittest.TestCase):
             step_mm=(1.0, 1.0),
             sensor_pixel_size_um=20.0,
             magnification=20.0,
-            flatfield_correction=True
+            flatfield_correction=True,
         ) as params:
             output_filename = None
 
@@ -116,15 +116,15 @@ class StitcherTest(unittest.TestCase):
 
     def test_stitch_with_pyramid_and_zarr_out(self) -> None:
         with temporary_image_directory_params(
-                n_rows=5,
-                n_cols=5,
-                # Exactly non-overlapping images aligned in a grid.
-                im_size=ImagePlaneDims(1000, 1000),
-                channel_names=["DAPI", "FITC", "TRITC"],
-                step_mm=(1.0, 1.0),
-                sensor_pixel_size_um=20.0,
-                magnification=20.0,
-                pyramid_levels=6
+            n_rows=5,
+            n_cols=5,
+            # Exactly non-overlapping images aligned in a grid.
+            im_size=ImagePlaneDims(1000, 1000),
+            channel_names=["DAPI", "FITC", "TRITC"],
+            step_mm=(1.0, 1.0),
+            sensor_pixel_size_um=20.0,
+            magnification=20.0,
+            pyramid_levels=6,
         ) as params:
             output_filename = None
 

--- a/image_stitcher/testutil.py
+++ b/image_stitcher/testutil.py
@@ -37,7 +37,7 @@ def temporary_image_directory_params(
     magnification: float = 20.0,
     disk_based_output_arr: bool = False,
     pyramid_levels: Optional[int] = None,
-    flatfield_correction: bool = False
+    flatfield_correction: bool = False,
 ) -> Generator[StitchingComputedParameters, None, None]:
     """Set up the files that the computed parameters requires for setup.
 
@@ -83,7 +83,9 @@ def temporary_image_directory_params(
                 )
                 for ch in channel_names:
                     im_file = base_dir / "0" / image_filename(fov_counter, ch)
-                    skimage.io.imsave(im_file, make_fake_image(fov_counter), check_contrast=False)
+                    skimage.io.imsave(
+                        im_file, make_fake_image(fov_counter), check_contrast=False
+                    )
                 fov_counter += 1
 
         coords = pd.DataFrame(coordinates)

--- a/test_fixtures/parameters_test/parameters.json
+++ b/test_fixtures/parameters_test/parameters.json
@@ -3,6 +3,7 @@
   "output_format": ".ome.zarr",
   "scan_pattern": "Unidirectional",
   "apply_flatfield": false,
+  "flatfield_manifest": null,
   "verbose": false,
   "force_stitch_to_disk": false,
   "num_pyramid_levels": null,


### PR DESCRIPTION
Allow the user to load flatfield files in .npy format by reading a flatfield_manifest.json, which maps channel indices to file names. 