### PR TITLE
Tiff stack handling

### DIFF
--- a/image_stitcher/stitcher_gui.py
+++ b/image_stitcher/stitcher_gui.py
@@ -341,20 +341,68 @@ class StitchingGUI(QWidget):
             return
 
         self.inputDirectory = str(acquisition_dir)
-        # Visually mark the drop area
-        self.inputDirDropArea.setText(f"Loaded: {acquisition_dir.name}")
-        self.inputDirDropArea.setStyleSheet("""
-            QLabel {border: 2px solid green; border-radius: 5px; background-color: #e0ffe0;}
-        """)
-        self.probeDatasetForZLayers()
+        
+        # Detect and display the acquisition format
+        try:
+            temp_params = StitchingParameters(
+                input_folder=self.inputDirectory,
+                output_format=OutputFormat.ome_zarr, 
+                scan_pattern=ScanPattern.unidirectional,
+            )
+            temp_stitcher = Stitcher(temp_params)
+            
+            # Check if it's multi-page TIFF format
+            if temp_stitcher.computed_parameters.is_multipage_tiff_format():
+                format_info = " (Multi-page TIFF)"
+            else:
+                format_info = " (Individual files)"
+                
+            # Visually mark the drop area
+            self.inputDirDropArea.setText(f"Loaded: {acquisition_dir.name}{format_info}")
+            self.inputDirDropArea.setStyleSheet("""
+                QLabel {border: 2px solid green; border-radius: 5px; background-color: #e0ffe0;}
+            """)
+            self.probeDatasetForZLayers()
+            
+        except Exception as e:
+            logging.warning(f"Could not detect acquisition format: {e}")
+            # Fallback to original behavior
+            self.inputDirDropArea.setText(f"Loaded: {acquisition_dir.name}")
+            self.inputDirDropArea.setStyleSheet("""
+                QLabel {border: 2px solid green; border-radius: 5px; background-color: #e0ffe0;}
+            """)
+            self.probeDatasetForZLayers()
 
     def selectInputDirectory(self) -> None: # Kept for now, can be removed if button is fully replaced
         dir = QFileDialog.getExistingDirectory(self, "Select Input Image Folder")
         if dir:
             self.inputDirectory = dir
-            self.inputDirDropArea.setText(f"Loaded: {pathlib.Path(dir).name}")
-            self.inputDirDropArea.setStyleSheet("""QLabel {border: 2px solid green; border-radius: 5px; background-color: #e0ffe0;}""")
-            self.probeDatasetForZLayers()
+            
+            # Detect and display the acquisition format
+            try:
+                temp_params = StitchingParameters(
+                    input_folder=self.inputDirectory,
+                    output_format=OutputFormat.ome_zarr, 
+                    scan_pattern=ScanPattern.unidirectional,
+                )
+                temp_stitcher = Stitcher(temp_params)
+                
+                # Check if it's multi-page TIFF format
+                if temp_stitcher.computed_parameters.is_multipage_tiff_format():
+                    format_info = " (Multi-page TIFF)"
+                else:
+                    format_info = " (Individual files)"
+                    
+                self.inputDirDropArea.setText(f"Loaded: {pathlib.Path(dir).name}{format_info}")
+                self.inputDirDropArea.setStyleSheet("""QLabel {border: 2px solid green; border-radius: 5px; background-color: #e0ffe0;}""")
+                self.probeDatasetForZLayers()
+                
+            except Exception as e:
+                logging.warning(f"Could not detect acquisition format: {e}")
+                # Fallback to original behavior
+                self.inputDirDropArea.setText(f"Loaded: {pathlib.Path(dir).name}")
+                self.inputDirDropArea.setStyleSheet("""QLabel {border: 2px solid green; border-radius: 5px; background-color: #e0ffe0;}""")
+                self.probeDatasetForZLayers()
 
     def probeDatasetForZLayers(self) -> None:
         if not self.inputDirectory:


### PR DESCRIPTION
This pull request adds support for multi-page TIFF files to the image stitcher workflow. The implementation introduces a `new parse_multipage_tiff()` method in `StitchingComputedParameters` that detects multi-page TIFF files containing "stack" in their filenames and parses them using the `tifffile` library. 

The method extracts individual pages from each multi-page TIFF file, maps them to z-levels and channels based on the coordinates.csv file, and creates AcquisitionMetadata objects with a new frame_idx field to track the page index within each file. The stitcher's `load_image()` method has been updated to handle both single files and multi-page TIFF files by checking for the frame_idx attribute and using tifffile to read specific pages when needed.

The GUI now automatically detects the acquisition format and displays whether it's using multi-page TIFF or individual files in the directory drop area. The format detection is performed by checking for "_stack" files in the first timepoint directory, and the parsing logic automatically chooses between the original parse_acquisition_metadata() method for individual files or the new parse_multipage_tiff() method for multi-page TIFF files.